### PR TITLE
#3 Feat: delete http url and add /api endpoint on swagger server

### DIFF
--- a/src/main/java/kahlua/KahluaProject/config/SwaggerConfig.java
+++ b/src/main/java/kahlua/KahluaProject/config/SwaggerConfig.java
@@ -18,8 +18,7 @@ import org.springframework.context.annotation.Configuration;
         info = @Info(title = "Kahluaband API 명세서",
                 description = "Kahluaband 홈페이지 API 명세서",
                 version = "v1"),
-        servers = {@Server(url = "http://kahluaband.com", description = "http url"),
-                @Server(url = "https://kahluaband.com", description = "https url"),
+        servers = {@Server(url = "https://kahluaband.com/api", description = "https url"),
                 @Server(url = "/", description = "Default Server URL")})
 @RequiredArgsConstructor
 @Configuration


### PR DESCRIPTION
## #️⃣연관된 이슈

> #3 

## 📝작업 내용

> 스웨거 서버 리스트에서 http url 제거
> https url에 /api 엔드포인트 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)