### PR TITLE
#76 Feat: ApplyInfo, TicketInfo entity 생성

### DIFF
--- a/src/main/java/kahlua/KahluaProject/domain/applyInfo/ApplyInfo.java
+++ b/src/main/java/kahlua/KahluaProject/domain/applyInfo/ApplyInfo.java
@@ -1,0 +1,23 @@
+package kahlua.KahluaProject.domain.applyInfo;
+
+import jakarta.persistence.*;
+import kahlua.KahluaProject.vo.ApplyInfoData;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApplyInfo {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, columnDefinition = "bigint")
+    private Long id;
+
+    @Column(columnDefinition = "json")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private ApplyInfoData applyInfoData;
+}

--- a/src/main/java/kahlua/KahluaProject/domain/ticketInfo/TicketInfo.java
+++ b/src/main/java/kahlua/KahluaProject/domain/ticketInfo/TicketInfo.java
@@ -18,7 +18,7 @@ public class TicketInfo {
     @Column(nullable = false, columnDefinition = "bigint")
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "text")
     private String posterImageUrl;
 
     @Column(columnDefinition = "json")

--- a/src/main/java/kahlua/KahluaProject/domain/ticketInfo/TicketInfo.java
+++ b/src/main/java/kahlua/KahluaProject/domain/ticketInfo/TicketInfo.java
@@ -1,0 +1,27 @@
+package kahlua.KahluaProject.domain.ticketInfo;
+
+import jakarta.persistence.*;
+import kahlua.KahluaProject.vo.TicketInfoData;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TicketInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, columnDefinition = "bigint")
+    private Long id;
+
+    @Column(nullable = false)
+    private String posterImageUrl;
+
+    @Column(columnDefinition = "json")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private TicketInfoData ticketInfoData;
+}

--- a/src/main/java/kahlua/KahluaProject/vo/ApplyInfoData.java
+++ b/src/main/java/kahlua/KahluaProject/vo/ApplyInfoData.java
@@ -1,0 +1,50 @@
+package kahlua.KahluaProject.vo;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record ApplyInfoData(
+        @Schema(description = "기수", example = "23")
+        String term,
+
+        @Schema(description = "모집 시작일", example = "2024-03-01T00:00:00")
+        LocalDateTime startDate,
+
+        @Schema(description = "모집 마감일", example = "2024-03-10T23:59:59")
+        LocalDateTime endDate,
+
+        @Schema(description = "보컬 모집 마감일", example = "2024-03-11T23:59:59")
+        LocalDateTime vocalEndDate,
+
+        @Schema(description = "서류 지원 마감일", example = "2024-03-10T23:59:59")
+        LocalDateTime applicationDeadline,
+
+        @Schema(description = "서류 지원 설명")
+        String applicationDescription,
+
+        @Schema(description = "면접 날짜 일정", example = "2024-03-15T18:00:00")
+        LocalDateTime interviewSchedule,
+
+        @Schema(description = "면접 설명")
+        String interviewDescription,
+
+        @Schema(description = "뒷풀이", example = "2024-03-15T20:00:00")
+        LocalDateTime afterParty,
+
+        @Schema(description = "최종 합격 발표 일정", example = "2024-03-20")
+        LocalDate finalAnnouncementSchedule,
+
+        @Schema(description = "최종 합격 발표 설명")
+        String finalAnnouncementDescription,
+
+        @Schema(description = "활동 일정", example = "2025-03-25")
+        LocalDate activitySchedule,
+
+        @Schema(description = "활동 설명")
+        String activityDescription
+) {}

--- a/src/main/java/kahlua/KahluaProject/vo/TicketInfoData.java
+++ b/src/main/java/kahlua/KahluaProject/vo/TicketInfoData.java
@@ -1,0 +1,40 @@
+package kahlua.KahluaProject.vo;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record TicketInfoData(
+        @Schema(description = "공연 제목", example = "2024년 3월 정기 공연")
+        String title,
+
+        @Schema(description = "장소", example = "001 클럽")
+        String venue,
+
+        @Schema(description = "주소", example = "서울 마포구 월드컵북로2길 49")
+        String address,
+
+        @Schema(description = "일시", example = "2024-03-02T19:00:00")
+        LocalDateTime dateTime,
+
+        @Schema(description = "신입생 가격", example = "0")
+        String newStudentPrice,
+
+        @Schema(description = "신입생 최대 구매 개수", example = "1")
+        int newStudentMaxPurchase,
+
+        @Schema(description = "일반 가격", example = "5000")
+        String generalPrice,
+
+        @Schema(description = "일반 최대 구매 개수", example = "5")
+        int generalMaxPurchase,
+
+        @Schema(description = "예매 시작 날짜", example = "2024-02-20T10:00:00")
+        LocalDateTime bookingStartDate,
+
+        @Schema(description = "예매 마감 날짜", example = "2024-03-01T23:59:59")
+        LocalDateTime bookingEndDate
+) {}

--- a/src/main/java/kahlua/KahluaProject/vo/TicketInfoData.java
+++ b/src/main/java/kahlua/KahluaProject/vo/TicketInfoData.java
@@ -21,10 +21,10 @@ public record TicketInfoData(
         LocalDateTime dateTime,
 
         @Schema(description = "신입생 가격", example = "0")
-        String newStudentPrice,
+        String freshmanPrice,
 
         @Schema(description = "신입생 최대 구매 개수", example = "1")
-        int newStudentMaxPurchase,
+        int freshmanMaxPurchase,
 
         @Schema(description = "일반 가격", example = "5000")
         String generalPrice,


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) #이슈번호, #이슈번호
- #76 

## 📝작업 내용
ApplyInfoData, TicketInfoData 모두 데이터들을 모두 필드로 관리할 필요는 없을 것 같아서 Json 타입으로 데이터 저장하려고 합니다!

### 스크린샷 (선택)
- 예시 Data 입니다!
<img width="976" alt="스크린샷 2024-10-09 오후 2 18 59" src="https://github.com/user-attachments/assets/89681093-2757-49da-b135-f6f9be175dc1">



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
