### PR TITLE
#69 Feat: Reservation Entity 생성

### DIFF
--- a/src/main/java/kahlua/KahluaProject/domain/reservation/Reservation.java
+++ b/src/main/java/kahlua/KahluaProject/domain/reservation/Reservation.java
@@ -1,0 +1,48 @@
+package kahlua.KahluaProject.domain.reservation;
+
+import jakarta.persistence.*;
+import kahlua.KahluaProject.domain.BaseEntity;
+import kahlua.KahluaProject.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static jakarta.persistence.FetchType.*;
+import static jakarta.persistence.GenerationType.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Reservation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "club_room_username")
+    private String clubRoomUsername; // 동방 예약자명(팀명)
+
+    @Column(name = "reservation_date", nullable = false)
+    private LocalDate reservationDate; // 예약날짜
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime; // 사용 시작 시간
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime; // 사용 종료 시간
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reservation_status", nullable = false)
+    private ReservationStatus status; // 예약 상태 - 진행중, 예약됨, 취소됨
+}

--- a/src/main/java/kahlua/KahluaProject/domain/reservation/Reservation.java
+++ b/src/main/java/kahlua/KahluaProject/domain/reservation/Reservation.java
@@ -30,6 +30,10 @@ public class Reservation extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reservation_type", nullable = false)
+    private ReservationType type; // 개인, 팀 구분
+
     @Column(name = "club_room_username")
     private String clubRoomUsername; // 동방 예약자명(팀명)
 

--- a/src/main/java/kahlua/KahluaProject/domain/reservation/ReservationStatus.java
+++ b/src/main/java/kahlua/KahluaProject/domain/reservation/ReservationStatus.java
@@ -1,0 +1,6 @@
+package kahlua.KahluaProject.domain.reservation;
+
+public enum ReservationStatus {
+
+    PROCEEDING, RESERVED, CANCELLED
+}

--- a/src/main/java/kahlua/KahluaProject/domain/reservation/ReservationType.java
+++ b/src/main/java/kahlua/KahluaProject/domain/reservation/ReservationType.java
@@ -1,0 +1,6 @@
+package kahlua.KahluaProject.domain.reservation;
+
+public enum ReservationType {
+
+    SOLO, TEAM
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #69 

## 📝작업 내용

> 동방 예약 기능 관련 엔티티 만들기!

> 사용 시작 시간, 종료 시간으로 범위를 지정해 예약 가능 여부를 검사할 예정입니다.
> 30분 단위 예약 검증 로직 추가하겠슴니다.
> 예약 상태를 진행중, 예약됨으로 구분하여 예약을 확정하기 전에 우선권을 부여하는 로직을 구현할 예정입니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
