### PR TITLE
#74 Feat: add create, view, delete comments functions

### DIFF
--- a/src/main/java/kahlua/KahluaProject/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/kahlua/KahluaProject/apipayload/code/status/ErrorStatus.java
@@ -43,9 +43,12 @@ public enum ErrorStatus implements BaseCode {
     // 웹소켓 에러
     WEBSOCKET_SESSION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "WEBSOCKET SESSION UNAUTHORIZED", "웹소켓 연결에 실패했습니다."),
 
-    //게시판 에러
+    // 게시판 에러
     IMAGE_NOT_UPLOAD(HttpStatus.BAD_REQUEST, "IMAGE_NOT_UPLOAD", "이미지 업로드 개수를 초과하였습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_NOT_FOUND", "존재하지 않는 게시글입니다."),
+
+    // 댓글 에러
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_NOT_FOUND", "존재하지 않는 댓글입니다."),
 
     // 예약 에러
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION NOT FOUND", "예약내역을 찾을 수 없습니다.");

--- a/src/main/java/kahlua/KahluaProject/config/QueryDslConfig.java
+++ b/src/main/java/kahlua/KahluaProject/config/QueryDslConfig.java
@@ -2,6 +2,7 @@ package kahlua.KahluaProject.config;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,6 +11,7 @@ import org.springframework.context.annotation.Configuration;
 @RequiredArgsConstructor
 public class QueryDslConfig {
 
+    @PersistenceContext
     private final EntityManager entityManager;
 
     @Bean

--- a/src/main/java/kahlua/KahluaProject/config/SecurityConfig.java
+++ b/src/main/java/kahlua/KahluaProject/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                         .requestMatchers( "/api-docs/**", "/swagger-ui/**", "/swagger-ui.html/**", "/v3/api-docs/**", "/swagger-ui/index.html#/**").permitAll()
                         .requestMatchers("/v1/auth/sign-out/**", "v1/auth/recreate/**","/v1/user/**", "/v1/admin/**").authenticated()
                         .requestMatchers("v1/reservation/**").hasAnyAuthority("KAHLUA", "ADMIN")
+                        .requestMatchers("v1/comment/**").hasAnyAuthority("KAHLUA", "ADMIN")
                         .anyRequest().permitAll())
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(exceptionFilter, JwtFilter.class);

--- a/src/main/java/kahlua/KahluaProject/controller/CommentController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/CommentController.java
@@ -1,0 +1,46 @@
+package kahlua.KahluaProject.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kahlua.KahluaProject.apipayload.ApiResponse;
+import kahlua.KahluaProject.dto.post.request.CommentsCreateRequest;
+import kahlua.KahluaProject.dto.post.response.CommentsCreateResponse;
+import kahlua.KahluaProject.dto.post.response.CommentsItemResponse;
+import kahlua.KahluaProject.dto.post.response.CommentsListResponse;
+import kahlua.KahluaProject.security.AuthDetails;
+import kahlua.KahluaProject.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "게시판 댓글", description = "게시판 댓글 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/comment")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/{post_id}/create")
+    @Operation(summary = "댓글 작성", description = "게시판 댓글을 작성합니다.")
+    public ApiResponse<CommentsCreateResponse> createComment(@PathVariable("post_id") Long post_id, @RequestBody CommentsCreateRequest commentsCreateRequest, @AuthenticationPrincipal AuthDetails authDetails) {
+        CommentsCreateResponse commentsCreateResponse = commentService.createComment(post_id, commentsCreateRequest, authDetails.user());
+        return ApiResponse.onSuccess(commentsCreateResponse);
+    }
+
+    @GetMapping("/{post_id}/list")
+    @Operation(summary = "전체 댓글 조회", description = "게시글에 달린 댓글을 조회합니다.")
+    public ApiResponse<CommentsListResponse> viewCommentsList(@PathVariable("post_id") Long post_id) {
+        CommentsListResponse commentsListResponse = commentService.viewCommentsList(post_id);
+        return ApiResponse.onSuccess(commentsListResponse);
+    }
+
+    @DeleteMapping("/{post_id}/{comment_id}/delete")
+    @Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다.")
+    public ApiResponse<CommentsItemResponse> deleteComment(@PathVariable("post_id") Long post_id,
+                                                           @PathVariable("comment_id") Long comment_id) {
+        CommentsItemResponse commentsItemResponse = commentService.deleteComment(post_id, comment_id);
+        return ApiResponse.onSuccess(commentsItemResponse);
+    }
+}

--- a/src/main/java/kahlua/KahluaProject/converter/CommentConverter.java
+++ b/src/main/java/kahlua/KahluaProject/converter/CommentConverter.java
@@ -1,0 +1,59 @@
+package kahlua.KahluaProject.converter;
+
+import kahlua.KahluaProject.domain.post.Comment;
+import kahlua.KahluaProject.domain.post.Post;
+import kahlua.KahluaProject.domain.user.User;
+import kahlua.KahluaProject.dto.post.request.CommentsCreateRequest;
+import kahlua.KahluaProject.dto.post.response.CommentsCreateResponse;
+import kahlua.KahluaProject.dto.post.response.CommentsItemResponse;
+import kahlua.KahluaProject.dto.post.response.CommentsListResponse;
+
+import java.util.List;
+import java.util.Optional;
+
+public class CommentConverter {
+
+    public static Comment toComment(CommentsCreateRequest commentsCreateRequest, Post existingPost, User user, Comment parentComment) {
+        return Comment.builder()
+                .post(existingPost)
+                .user(user)
+                .content(commentsCreateRequest.getContent())
+                .parentComment(parentComment)
+                .build();
+    }
+
+    public static CommentsCreateResponse toCommentCreateResponse(Comment comment) {
+        Long parentCommentId = Optional.ofNullable(comment.getParentComment())
+                .map(Comment::getId)
+                .orElse(null);
+
+        return CommentsCreateResponse.builder()
+                .id(comment.getId())
+                .postId(comment.getPost().getId())
+                .user(comment.getUser().getName())
+                .content(comment.getContent())
+                .parentCommentId(parentCommentId)
+                .build();
+    }
+
+    public static CommentsItemResponse toCommentItemResponse(Comment comment) {
+        Long parentCommentId = Optional.ofNullable(comment.getParentComment())
+                .map(Comment::getId)
+                .orElse(null);
+
+        return CommentsItemResponse.builder()
+                .id(comment.getId())
+                .postId(comment.getPost().getId())
+                .user(comment.getUser().getName())
+                .content(comment.getContent())
+                .parentCommentId(parentCommentId)
+                .build();
+    }
+
+    public static CommentsListResponse toCommentListResponse(List<CommentsItemResponse> commentsItemResponses) {
+        return CommentsListResponse.builder()
+                .comments_count(commentsItemResponses.stream().count())
+                .comments(commentsItemResponses)
+                .build();
+    }
+}

--- a/src/main/java/kahlua/KahluaProject/converter/PostConverter.java
+++ b/src/main/java/kahlua/KahluaProject/converter/PostConverter.java
@@ -42,7 +42,7 @@ public class PostConverter {
                 .likes(post.getLikes())
                 .imageUrls(imageUrls)
                 .created_at(post.getCreatedAt())
-                .created_at(post.getUpdatedAt())
+                .updated_at(post.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/kahlua/KahluaProject/domain/post/Comment.java
+++ b/src/main/java/kahlua/KahluaProject/domain/post/Comment.java
@@ -7,6 +7,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,6 +16,8 @@ import java.util.List;
 @Entity
 @Builder
 @Getter
+@SQLDelete(sql = "UPDATE comment SET deleted_at = NOW() where comment_id = ?")
+@Where(clause = "deleted_at is NULL")
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "comment")
@@ -36,11 +40,11 @@ public class Comment extends BaseEntity {
     private User user;
 
     // 부모 댓글
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "parent_comment_id")
     private Comment parentComment;
 
-    // 자식 댓글
-    @OneToMany(mappedBy = "parentComment")
+    // 자식 댓글 (REMOVE를 포함하지 않으므로 부모 댓글이 삭제되어도 자식 댓글은 그대로 유지된다.)
+    @OneToMany(mappedBy = "parentComment", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private List<Comment> childComments = new ArrayList<>();
 }

--- a/src/main/java/kahlua/KahluaProject/domain/post/Post.java
+++ b/src/main/java/kahlua/KahluaProject/domain/post/Post.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +17,8 @@ import java.util.List;
 @Entity
 @Builder
 @Getter
+@SQLDelete(sql = "UPDATE post SET deleted_at = NOW() where post_id = ?")
+@Where(clause = "deleted_at is NULL")
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "post")

--- a/src/main/java/kahlua/KahluaProject/dto/post/response/CommentsCreateResponse.java
+++ b/src/main/java/kahlua/KahluaProject/dto/post/response/CommentsCreateResponse.java
@@ -1,14 +1,18 @@
-package kahlua.KahluaProject.dto.post.request;
+package kahlua.KahluaProject.dto.post.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
+@Builder
 @Getter
-@AllArgsConstructor
-@NoArgsConstructor
-public class CommentsCreateRequest {
+public class CommentsCreateResponse {
+
+    @Schema(description = "댓글 번호", example = "1")
+    private Long id;
+
+    @Schema(description = "게시글 번호", example = "1")
+    private Long postId;
 
     @Schema(description = "댓글 작성자", example = "깔루아 홍길동")
     private String user;

--- a/src/main/java/kahlua/KahluaProject/dto/post/response/CommentsItemResponse.java
+++ b/src/main/java/kahlua/KahluaProject/dto/post/response/CommentsItemResponse.java
@@ -1,14 +1,20 @@
-package kahlua.KahluaProject.dto.post.request;
+package kahlua.KahluaProject.dto.post.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Getter
-@AllArgsConstructor
-@NoArgsConstructor
-public class CommentsCreateRequest {
+@Builder
+public class CommentsItemResponse {
+
+    @Schema(description = "댓글 번호", example = "1")
+    private Long id;
+
+    @Schema(description = "게시글 번호", example = "1")
+    private Long postId;
 
     @Schema(description = "댓글 작성자", example = "깔루아 홍길동")
     private String user;
@@ -18,4 +24,7 @@ public class CommentsCreateRequest {
 
     @Schema(description = "대댓글인 경우 부모 댓글 id", example = "네 수고하세요.")
     private Long parentCommentId;
+
+    @Schema(description = "삭제된 날짜", example = "2024.01.01")
+    private LocalDateTime deletedAt;
 }

--- a/src/main/java/kahlua/KahluaProject/dto/post/response/CommentsListResponse.java
+++ b/src/main/java/kahlua/KahluaProject/dto/post/response/CommentsListResponse.java
@@ -1,0 +1,18 @@
+package kahlua.KahluaProject.dto.post.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class CommentsListResponse {
+
+    @Schema(description = "전체 댓글 수")
+    private Long comments_count;
+
+    @Schema(description = "댓글 리스트")
+    private List<CommentsItemResponse> comments;
+}

--- a/src/main/java/kahlua/KahluaProject/dto/post/response/PostUpdateResponse.java
+++ b/src/main/java/kahlua/KahluaProject/dto/post/response/PostUpdateResponse.java
@@ -1,0 +1,37 @@
+package kahlua.KahluaProject.dto.post.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+@Getter
+public class PostUpdateResponse {
+
+    @Schema(description = "아이디(번호)", example = "1")
+    private Long id;
+
+    @Schema(description = "게시글 제목", example = "2024년 9월 정기공연")
+    private String title;
+
+    @Schema(description = "게시글 내용", example = "안녕하세요 깔루아 기장입니다. 감사합니다.")
+    private String content;
+
+    @Schema(description = "게시글 작성자", example = "관리자")
+    private String writer;
+
+    @Schema(description = "게시글 좋아요 수", example = "13")
+    private int likes;
+
+    @Schema(description = "게시글 사진 리스트", example = "https://bucketname.s3.region.amazonaws.com/image1.jpg")
+    private List<PostImageGetResponse> imageUrls;
+
+    @Schema(description = "작성한 날짜", example = "2024-08-01T00:00:00")
+    private LocalDateTime created_at;
+
+    @Schema(description = "수정한 날짜", example = "2024-08-10T00:00:00")
+    private LocalDateTime updated_at;
+}

--- a/src/main/java/kahlua/KahluaProject/repository/comment/CommentRepository.java
+++ b/src/main/java/kahlua/KahluaProject/repository/comment/CommentRepository.java
@@ -1,0 +1,7 @@
+package kahlua.KahluaProject.repository.comment;
+
+import kahlua.KahluaProject.domain.post.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/kahlua/KahluaProject/repository/comment/CommentRepositoryCustom.java
+++ b/src/main/java/kahlua/KahluaProject/repository/comment/CommentRepositoryCustom.java
@@ -1,0 +1,10 @@
+package kahlua.KahluaProject.repository.comment;
+
+import kahlua.KahluaProject.domain.post.Comment;
+
+import java.util.List;
+
+public interface CommentRepositoryCustom {
+
+    List<Comment> findPureCommentListByPost(Long postId);
+}

--- a/src/main/java/kahlua/KahluaProject/repository/comment/CommentRepositoryImpl.java
+++ b/src/main/java/kahlua/KahluaProject/repository/comment/CommentRepositoryImpl.java
@@ -1,0 +1,38 @@
+package kahlua.KahluaProject.repository.comment;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kahlua.KahluaProject.domain.post.Comment;
+import kahlua.KahluaProject.domain.post.QComment;
+import kahlua.KahluaProject.domain.post.QPost;
+import kahlua.KahluaProject.domain.user.QUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static kahlua.KahluaProject.domain.post.QComment.comment;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentRepositoryImpl implements CommentRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    // postId에 해당하는 댓글 리스트를 페이지 단위로 반환
+    public List<Comment> findPureCommentListByPost(Long postId) {
+        QComment parentComment = new QComment("parentComment");
+        QUser user = QUser.user;
+        QPost post = QPost.post;
+
+        return jpaQueryFactory
+                .select(comment)
+                .from(comment)
+                .join(comment.post, post).fetchJoin()
+                .join(comment.user, user).fetchJoin()
+                .leftJoin(comment.parentComment, parentComment).fetchJoin()
+                .where(comment.post.id.eq(postId))
+                .orderBy(comment.createdAt.asc())
+                .fetch();
+    }
+}

--- a/src/main/java/kahlua/KahluaProject/repository/post/PostRepository.java
+++ b/src/main/java/kahlua/KahluaProject/repository/post/PostRepository.java
@@ -6,6 +6,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-
-    Optional<Post> findById(Long id);
 }

--- a/src/main/java/kahlua/KahluaProject/service/CommentService.java
+++ b/src/main/java/kahlua/KahluaProject/service/CommentService.java
@@ -1,0 +1,94 @@
+package kahlua.KahluaProject.service;
+
+import jakarta.persistence.EntityManager;
+import kahlua.KahluaProject.apipayload.code.status.ErrorStatus;
+import kahlua.KahluaProject.converter.CommentConverter;
+import kahlua.KahluaProject.domain.post.Comment;
+import kahlua.KahluaProject.domain.post.Post;
+import kahlua.KahluaProject.domain.user.User;
+import kahlua.KahluaProject.dto.post.request.CommentsCreateRequest;
+import kahlua.KahluaProject.dto.post.response.CommentsCreateResponse;
+import kahlua.KahluaProject.dto.post.response.CommentsItemResponse;
+import kahlua.KahluaProject.dto.post.response.CommentsListResponse;
+import kahlua.KahluaProject.exception.GeneralException;
+import kahlua.KahluaProject.repository.comment.CommentRepository;
+import kahlua.KahluaProject.repository.comment.CommentRepositoryCustom;
+import kahlua.KahluaProject.repository.post.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.SoftDelete;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final CommentRepositoryCustom commentRepositoryCustom;
+    private final EntityManager em;
+
+    @Transactional
+    public CommentsCreateResponse createComment(Long post_id, CommentsCreateRequest commentsCreateRequest, User user) {
+
+        // 선택한 게시글이 존재하는 지 확인
+        Post existingPost = postRepository.findById(post_id)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+
+        Comment parentComment = null;
+        if (commentsCreateRequest.getParentCommentId() != null) {
+            parentComment = commentRepository.findById(commentsCreateRequest.getParentCommentId())
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+        }
+
+        Comment comment = CommentConverter.toComment(commentsCreateRequest, existingPost, user, parentComment);
+        commentRepository.save(comment);
+
+        CommentsCreateResponse commentsCreateResponse = CommentConverter.toCommentCreateResponse(comment);
+        return commentsCreateResponse;
+    }
+
+    // 게시글 내의 댓글 전체 조회
+    @Transactional
+    public CommentsListResponse viewCommentsList(Long post_id) {
+
+        // 선택한 게시글이 존재하는 지 확인
+        postRepository.findById(post_id)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+
+        List<CommentsItemResponse> commentsItemResponses = new ArrayList<>();
+
+        List<Comment> commentList = commentRepositoryCustom.findPureCommentListByPost(post_id);
+
+        for (Comment comment : commentList) {
+            CommentsItemResponse commentsItemResponse = CommentConverter.toCommentItemResponse(comment);
+            commentsItemResponses.add(commentsItemResponse);
+        }
+
+        CommentsListResponse commentsListResponse = CommentConverter.toCommentListResponse(commentsItemResponses);
+        return commentsListResponse;
+    }
+
+    @Transactional
+    @SoftDelete
+    public CommentsItemResponse deleteComment(Long post_id, Long comment_id) {
+
+        // 선택한 게시글이 존재하는 지 확인
+        postRepository.findById(post_id)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+
+        Comment comment = commentRepository.findById(comment_id)
+                        .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+
+        if (comment.getDeletedAt() == null)
+            commentRepository.delete(comment);
+
+
+        CommentsItemResponse commentsItemResponse = CommentConverter.toCommentItemResponse(comment);
+        return commentsItemResponse;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #74 

## 📝작업 내용

> 댓글 도메인 수정
> 댓글, 대댓글 생성, 조회, 삭제 기능 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 댓글 삭제 시 SoftDelete를 사용해서 디비에는 남아있고 조회만 안되도록 했습니다.
