### PR TITLE
#74 Fix: change method to patch imageUrls

### DIFF
--- a/src/main/java/kahlua/KahluaProject/domain/post/Post.java
+++ b/src/main/java/kahlua/KahluaProject/domain/post/Post.java
@@ -58,16 +58,18 @@ public class Post extends BaseEntity {
         ImageUrls.add(postImage);
     }
 
-    public void update(String title, String content, List<PostImage> ImageUrls) {
+    public void update(String title, String content) {
         if (title != null) {
             this.title = title;
         }
         if (content != null) {
             this.content = content;
         }
-        if (ImageUrls != null) {
-            this.ImageUrls = ImageUrls;
-        }
+    }
+
+    public void updateImages(List<PostImage> newImages) {
+        this.ImageUrls.clear(); // 기존 이미지 리스트 비우기
+        this.ImageUrls.addAll(newImages);
     }
 
     public void increaseLikes() {

--- a/src/main/java/kahlua/KahluaProject/repository/PostImageRepository.java
+++ b/src/main/java/kahlua/KahluaProject/repository/PostImageRepository.java
@@ -1,7 +1,12 @@
 package kahlua.KahluaProject.repository;
 
+import kahlua.KahluaProject.domain.post.Post;
 import kahlua.KahluaProject.domain.post.PostImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PostImageRepository extends JpaRepository<PostImage, Long> {
+
+    List<PostImage> deleteAllByPost(Post post);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #74 

## 📝작업 내용

> 게시글 이미지 업데이트 코드 수정
> 빈 리스트를 넘기면 기존 사진 삭제, null 값으로 요청하면 기존 이미지 존재하도록 수정하였습니다.