### PR TITLE
Feature: 공연리스트 api, 공연 상세정보 조회 api 구현

### DIFF
--- a/src/main/java/kahlua/KahluaProject/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/kahlua/KahluaProject/apipayload/code/status/ErrorStatus.java
@@ -11,37 +11,37 @@ import org.springframework.http.HttpStatus;
 public enum ErrorStatus implements BaseCode {
 
     // 에러 응답 (둘 중 하나 삭제)
-    INTERNER_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error", "서버 에러"),
+    INTERNER_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal_Server_Error", "서버 에러"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 에러"),
 
     // 로그인 실패
-    LOGIN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "LOGIN FAIL", "아이디 또는 비밀번호를 확인하세요"),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER NOT FOUND", "사용자를 찾을 수 없습니다."),
+    LOGIN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "LOGIN_FAIL", "아이디 또는 비밀번호를 확인하세요"),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "금지된 접근입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "권한이 없습니다."),
-    PASSWORD_NOT_MATCH(HttpStatus.NOT_FOUND, "PASSWORD NOT MATCH", "비밀번호가 틀렸습니다."),
-    PASSWORD_INVALID(HttpStatus.NOT_FOUND, "PASSWORD INVALID", "유효하지 않은 password입니다."),
-    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "TOKEN INVALID", "토큰이 유효하지 않습니다."),
-    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "TOKEN INVALID", "토큰을 찾을 수 없습니다."),
-    ALREADY_EXIST_USER(HttpStatus.BAD_REQUEST, "ALREADY EXIST USER", "이미 존재하는 회원입니다."),
-    REDIS_NOT_FOUND(HttpStatus.NOT_FOUND, "REDIS NOT FOUND", "Redis 설정에 오류가 발생했습니다."),
+    PASSWORD_NOT_MATCH(HttpStatus.NOT_FOUND, "PASSWORD_NOT_MATCH", "비밀번호가 틀렸습니다."),
+    PASSWORD_INVALID(HttpStatus.NOT_FOUND, "PASSWORD_INVALID", "유효하지 않은 password입니다."),
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "TOKEN_INVALID", "토큰이 유효하지 않습니다."),
+    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "TOKEN_INVALID", "토큰을 찾을 수 없습니다."),
+    ALREADY_EXIST_USER(HttpStatus.BAD_REQUEST, "ALREADY_EXIST_USER", "이미 존재하는 회원입니다."),
+    REDIS_NOT_FOUND(HttpStatus.NOT_FOUND, "REDIS_NOT_FOUND", "Redis 설정에 오류가 발생했습니다."),
 
 
     // 세션 에러
     SESSION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "유효하지 않은 세션입니다."),
 
     // 티켓 에러
-    TICKET_NOT_FOUND(HttpStatus.NOT_FOUND, "TICKET NOT FOUND", "티켓을 찾을 수 없습니다."),
-    TICKET_COLUMN_INVALID(HttpStatus.BAD_REQUEST, "TICKET COLUMN INVALID", "올바르지 않은 티켓 속성입니다."),
-    ALREADY_EXIST_STUDENT_ID(HttpStatus.BAD_REQUEST, "ALREADY EXIST STUDENT_ID", "이미 존재하는 학번입니다."),
+    TICKET_NOT_FOUND(HttpStatus.NOT_FOUND, "TICKET_NOT_FOUND", "티켓을 찾을 수 없습니다."),
+    TICKET_COLUMN_INVALID(HttpStatus.BAD_REQUEST, "TICKET_COLUMN_INVALID", "올바르지 않은 티켓 속성입니다."),
+    ALREADY_EXIST_STUDENT_ID(HttpStatus.BAD_REQUEST, "ALREADY_EXIST_STUDENT_ID", "이미 존재하는 학번입니다."),
 
     //지원하기 에러
-    ALREADY_EXIST_APPLICANT(HttpStatus.BAD_REQUEST, "ALREADY EXIST APPLICANT", "이미 존재하는 지원자입니다."),
-    APPLICANT_NOT_FOUND(HttpStatus.NOT_FOUND, "APPLICANT NOT FOUND", "존재하지 않는 지원자입니다."),
-    APPLY_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "APPLY INFO NOT FOUND", "존재하지 않는 지원정보 입니다." ),
+    ALREADY_EXIST_APPLICANT(HttpStatus.BAD_REQUEST, "ALREADY_EXIST_APPLICANT", "이미 존재하는 지원자입니다."),
+    APPLICANT_NOT_FOUND(HttpStatus.NOT_FOUND, "APPLICANT_NOT_FOUND", "존재하지 않는 지원자입니다."),
+    APPLY_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "APPLY_INFO_NOT_FOUND", "존재하지 않는 지원정보 입니다." ),
 
     // 웹소켓 에러
-    WEBSOCKET_SESSION_UNAUTHORIZED(HttpStatus.BAD_REQUEST, "WEBSOCKET ERROR", "웹소켓 연결 과정에서 에러가 발생했습니다."),
+    WEBSOCKET_SESSION_UNAUTHORIZED(HttpStatus.BAD_REQUEST, "WEBSOCKET_ERROR", "웹소켓 연결 과정에서 에러가 발생했습니다."),
 
     // 게시판 에러
     IMAGE_NOT_UPLOAD(HttpStatus.BAD_REQUEST, "IMAGE_NOT_UPLOAD", "이미지 업로드 개수를 초과하였습니다."),
@@ -51,9 +51,12 @@ public enum ErrorStatus implements BaseCode {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_NOT_FOUND", "존재하지 않는 댓글입니다."),
 
     // 예약 에러
-    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION NOT FOUND", "예약내역을 찾을 수 없습니다.");
+    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION_NOT_FOUND", "예약내역을 찾을 수 없습니다."),
 
-    
+    //공연 관련 에러
+    TICKETINFO_NOT_FOUND(HttpStatus.NOT_FOUND,"TICKET_INFO<NOT_FOUND","공연 정보를 찾을 수 없습니다."),
+
+    ;
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kahlua/KahluaProject/controller/PerformanceController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/PerformanceController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "공연 페이지", description = "공연페이지 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/performance")
+@RequestMapping("/v1/performances")
 public class PerformanceController {
     private final PerformanceService performanceService;
 
@@ -28,3 +28,4 @@ public class PerformanceController {
 
 
 }
+

--- a/src/main/java/kahlua/KahluaProject/controller/PerformanceController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/PerformanceController.java
@@ -4,12 +4,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kahlua.KahluaProject.apipayload.ApiResponse;
 import kahlua.KahluaProject.dto.ticketInfo.response.PerformanceRes;
+import kahlua.KahluaProject.dto.ticketInfo.response.TicketInfoResponse;
 import kahlua.KahluaProject.service.PerformanceService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "공연 페이지", description = "공연페이지 관련 API")
 @RestController
@@ -26,6 +24,10 @@ public class PerformanceController {
         return ApiResponse.onSuccess(performanceService.getPerformances(cursor, limit));
     }
 
-
+    @GetMapping("/{ticketInfoId}")
+    @Operation(summary = "공연 상세정보 조회 API", description = "특정 공연의 상세정보를 조회하는 API입니다.")
+    public ApiResponse<PerformanceRes.performanceInfoDto> getPerformanceInfo(@PathVariable Long ticketInfoId){
+        return ApiResponse.onSuccess(performanceService.getPerformanceInfo(ticketInfoId));
+    }
 }
 

--- a/src/main/java/kahlua/KahluaProject/controller/PerformanceController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/PerformanceController.java
@@ -1,0 +1,30 @@
+package kahlua.KahluaProject.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kahlua.KahluaProject.apipayload.ApiResponse;
+import kahlua.KahluaProject.dto.ticketInfo.response.PerformanceRes;
+import kahlua.KahluaProject.service.PerformanceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "공연 페이지", description = "공연페이지 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/performance")
+public class PerformanceController {
+    private final PerformanceService performanceService;
+
+    @GetMapping
+    @Operation(summary = "공연 리스트 조회 API", description = "공연들을 조회하는 API입니다.")
+    public ApiResponse<PerformanceRes.performanceListDto> getPerformances(
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "8") int limit){
+        return ApiResponse.onSuccess(performanceService.getPerformances(cursor, limit));
+    }
+
+
+}

--- a/src/main/java/kahlua/KahluaProject/converter/TicketConverter.java
+++ b/src/main/java/kahlua/KahluaProject/converter/TicketConverter.java
@@ -107,6 +107,7 @@ public class TicketConverter {
                 .id(ticketInfo.getId())
                 .posterImageUrl(ticketInfo.getPosterImageUrl())
                 .title(ticketInfo.getTicketInfoData().title())
+                .content(ticketInfo.getTicketInfoData().content())
                 .venue(ticketInfo.getTicketInfoData().venue())
                 .address(ticketInfo.getTicketInfoData().address())
                 .dateTime(ticketInfo.getTicketInfoData().dateTime())

--- a/src/main/java/kahlua/KahluaProject/converter/TicketInfoConverter.java
+++ b/src/main/java/kahlua/KahluaProject/converter/TicketInfoConverter.java
@@ -14,7 +14,8 @@ public class TicketInfoConverter {
     public static PerformanceRes.performanceDto toPerformanceDto(TicketInfo info,PerformanceStatus status){
         return PerformanceRes.performanceDto.builder()
                 .ticketInfoId(info.getId())
-                .title(info.getTicketInfoData().toString())
+                .title(info.getTicketInfoData().title())
+                .content(info.getTicketInfoData().content())
                 .status(status)
                 .posterUrl(info.getPosterImageUrl())
                 .build();

--- a/src/main/java/kahlua/KahluaProject/converter/TicketInfoConverter.java
+++ b/src/main/java/kahlua/KahluaProject/converter/TicketInfoConverter.java
@@ -1,0 +1,23 @@
+package kahlua.KahluaProject.converter;
+
+import kahlua.KahluaProject.domain.ticketInfo.PerformanceStatus;
+import kahlua.KahluaProject.domain.ticketInfo.TicketInfo;
+import kahlua.KahluaProject.dto.ticketInfo.response.PerformanceRes;
+
+import java.time.LocalDateTime;
+
+import static kahlua.KahluaProject.domain.ticketInfo.PerformanceStatus.CLOSED;
+import static kahlua.KahluaProject.domain.ticketInfo.PerformanceStatus.OPEN;
+
+public class TicketInfoConverter {
+
+    public static PerformanceRes.performanceDto toPerformanceDto(TicketInfo info,PerformanceStatus status){
+        return PerformanceRes.performanceDto.builder()
+                .ticketInfoId(info.getId())
+                .title(info.getTicketInfoData().toString())
+                .status(status)
+                .posterUrl(info.getPosterImageUrl())
+                .build();
+    }
+
+}

--- a/src/main/java/kahlua/KahluaProject/domain/ticketInfo/PerformanceStatus.java
+++ b/src/main/java/kahlua/KahluaProject/domain/ticketInfo/PerformanceStatus.java
@@ -1,0 +1,6 @@
+package kahlua.KahluaProject.domain.ticketInfo;
+
+public enum PerformanceStatus {
+    OPEN,
+    CLOSED
+}

--- a/src/main/java/kahlua/KahluaProject/domain/ticketInfo/TicketInfo.java
+++ b/src/main/java/kahlua/KahluaProject/domain/ticketInfo/TicketInfo.java
@@ -3,14 +3,14 @@ package kahlua.KahluaProject.domain.ticketInfo;
 import jakarta.persistence.*;
 import kahlua.KahluaProject.domain.BaseEntity;
 import kahlua.KahluaProject.vo.TicketInfoData;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TicketInfo extends BaseEntity {
 

--- a/src/main/java/kahlua/KahluaProject/dto/ticketInfo/response/PerformanceRes.java
+++ b/src/main/java/kahlua/KahluaProject/dto/ticketInfo/response/PerformanceRes.java
@@ -33,6 +33,9 @@ public class PerformanceRes {
         @Schema(description = "공연 제목")
         String title;
 
+        @Schema(description = "공연 설명", example="#스물다섯_스물하나 #데이식스 #잔나비 #YB밴드 #백예린 #미도와_파라솔 ")
+        String content;
+
         @Schema(description = "공연 포스터 이미지")
         String posterUrl;
 

--- a/src/main/java/kahlua/KahluaProject/dto/ticketInfo/response/PerformanceRes.java
+++ b/src/main/java/kahlua/KahluaProject/dto/ticketInfo/response/PerformanceRes.java
@@ -42,4 +42,13 @@ public class PerformanceRes {
         @Schema(description = "공연 상태")
         PerformanceStatus status;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class performanceInfoDto{
+        TicketInfoResponse ticketInfoResponse;
+        @Schema(description = "공연 상태")
+        PerformanceStatus status;
+    }
 }

--- a/src/main/java/kahlua/KahluaProject/dto/ticketInfo/response/PerformanceRes.java
+++ b/src/main/java/kahlua/KahluaProject/dto/ticketInfo/response/PerformanceRes.java
@@ -1,0 +1,42 @@
+package kahlua.KahluaProject.dto.ticketInfo.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kahlua.KahluaProject.domain.ticketInfo.PerformanceStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+
+public class PerformanceRes {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class performanceListDto{
+        private List<performanceDto> performances;
+        @Schema(description = "다음 커서 값 (커서는 공연 id임)")
+        private Long nextcursor;
+        @Schema(description = "다음 페이지가 있을 경우 값=1, 없을 경우 = 0")
+        private boolean hasNext;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class performanceDto {
+
+        @Schema(description = "아이디")
+        Long ticketInfoId;
+
+        @Schema(description = "공연 제목")
+        String title;
+
+        @Schema(description = "공연 포스터 이미지")
+        String posterUrl;
+
+        @Schema(description = "공연 상태")
+        PerformanceStatus status;
+    }
+}

--- a/src/main/java/kahlua/KahluaProject/dto/ticketInfo/response/TicketInfoResponse.java
+++ b/src/main/java/kahlua/KahluaProject/dto/ticketInfo/response/TicketInfoResponse.java
@@ -20,6 +20,8 @@ public record TicketInfoResponse(
         @Schema(description = "공연 제목", example = "2024년 3월 정기 공연")
         String title,
 
+
+
         @Schema(description = "장소", example = "001 클럽")
         String venue,
 

--- a/src/main/java/kahlua/KahluaProject/dto/ticketInfo/response/TicketInfoResponse.java
+++ b/src/main/java/kahlua/KahluaProject/dto/ticketInfo/response/TicketInfoResponse.java
@@ -20,7 +20,8 @@ public record TicketInfoResponse(
         @Schema(description = "공연 제목", example = "2024년 3월 정기 공연")
         String title,
 
-
+        @Schema(description = "공연 설명", example="#스물다섯_스물하나 #데이식스 #잔나비 #YB밴드 #백예린 #미도와_파라솔 ")
+        String content,
 
         @Schema(description = "장소", example = "001 클럽")
         String venue,

--- a/src/main/java/kahlua/KahluaProject/repository/ticket/TicketInfoRepository.java
+++ b/src/main/java/kahlua/KahluaProject/repository/ticket/TicketInfoRepository.java
@@ -1,7 +1,15 @@
 package kahlua.KahluaProject.repository.ticket;
 
 import kahlua.KahluaProject.domain.ticketInfo.TicketInfo;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+@Repository
 public interface TicketInfoRepository extends JpaRepository<TicketInfo, Long> {
+    List<TicketInfo> findAllByOrderByIdDesc(Pageable pageable);
+
+    List<TicketInfo> findAllByIdLessThanOrderByIdDesc(Long cursor, Pageable pageable);
 }

--- a/src/main/java/kahlua/KahluaProject/service/PerformanceService.java
+++ b/src/main/java/kahlua/KahluaProject/service/PerformanceService.java
@@ -60,7 +60,7 @@ public class PerformanceService {
     }
 
     public PerformanceStatus checkStatus(TicketInfo ticketInfo) {
-        if (LocalDateTime.now().isAfter(ticketInfo.getTicketInfoData().dateTime())){
+        if (LocalDateTime.now().isAfter(ticketInfo.getTicketInfoData().bookingEndDate()) && LocalDateTime.now().isBefore(ticketInfo.getTicketInfoData().bookingStartDate())) {
             return CLOSED;
         } else{return OPEN;}
     }

--- a/src/main/java/kahlua/KahluaProject/service/PerformanceService.java
+++ b/src/main/java/kahlua/KahluaProject/service/PerformanceService.java
@@ -1,9 +1,13 @@
 package kahlua.KahluaProject.service;
 
+import kahlua.KahluaProject.apipayload.code.status.ErrorStatus;
+import kahlua.KahluaProject.converter.TicketConverter;
 import kahlua.KahluaProject.converter.TicketInfoConverter;
 import kahlua.KahluaProject.domain.ticketInfo.PerformanceStatus;
 import kahlua.KahluaProject.domain.ticketInfo.TicketInfo;
 import kahlua.KahluaProject.dto.ticketInfo.response.PerformanceRes;
+import kahlua.KahluaProject.dto.ticketInfo.response.TicketInfoResponse;
+import kahlua.KahluaProject.exception.GeneralException;
 import kahlua.KahluaProject.repository.ticket.TicketInfoRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -61,5 +65,14 @@ public class PerformanceService {
         } else{return OPEN;}
     }
 
+    public PerformanceRes.performanceInfoDto getPerformanceInfo(Long ticketInfoId){
+        TicketInfo ticketInfo = ticketInfoRepository.findById(ticketInfoId)
+                .orElseThrow(()->new GeneralException(ErrorStatus.TICKETINFO_NOT_FOUND));
+
+        return PerformanceRes.performanceInfoDto.builder()
+                .ticketInfoResponse(TicketConverter.toTicketInfoResponse(ticketInfo))
+                .status(checkStatus(ticketInfo))
+                .build();
+    }
 
 }

--- a/src/main/java/kahlua/KahluaProject/service/PerformanceService.java
+++ b/src/main/java/kahlua/KahluaProject/service/PerformanceService.java
@@ -1,0 +1,65 @@
+package kahlua.KahluaProject.service;
+
+import kahlua.KahluaProject.converter.TicketInfoConverter;
+import kahlua.KahluaProject.domain.ticketInfo.PerformanceStatus;
+import kahlua.KahluaProject.domain.ticketInfo.TicketInfo;
+import kahlua.KahluaProject.dto.ticketInfo.response.PerformanceRes;
+import kahlua.KahluaProject.repository.ticket.TicketInfoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static kahlua.KahluaProject.domain.ticketInfo.PerformanceStatus.CLOSED;
+import static kahlua.KahluaProject.domain.ticketInfo.PerformanceStatus.OPEN;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class PerformanceService {
+    private final TicketInfoRepository ticketInfoRepository;
+
+    public PerformanceRes.performanceListDto getPerformances(Long cursor, int limit){
+        Pageable pageable = PageRequest.of(0, limit+1);
+
+        List<TicketInfo> ticketInfos;
+        if (cursor == null) {
+            ticketInfos = ticketInfoRepository.findAllByOrderByIdDesc(pageable);
+        } else {
+            ticketInfos = ticketInfoRepository.findAllByIdLessThanOrderByIdDesc(cursor, pageable);
+        }
+
+
+        Long nextCursor = null;
+        boolean hasNext= ticketInfos.size() > limit;
+
+        if (hasNext){
+            TicketInfo lastTicketInfo= ticketInfos.get(limit-1);
+            nextCursor=lastTicketInfo.getId();
+            ticketInfos=ticketInfos.subList(0,limit);
+        }
+
+        List<PerformanceRes.performanceDto> ticketInfoDtos=ticketInfos.stream()
+                .map(ticketInfo -> TicketInfoConverter.toPerformanceDto(ticketInfo,checkStatus(ticketInfo)))
+                .collect(Collectors.toList());
+
+        return PerformanceRes.performanceListDto.builder()
+                .performances(ticketInfoDtos)
+                .nextcursor(nextCursor)
+                .hasNext(hasNext)
+                .build();
+    }
+
+    public PerformanceStatus checkStatus(TicketInfo ticketInfo) {
+        if (LocalDateTime.now().isAfter(ticketInfo.getTicketInfoData().dateTime())){
+            return CLOSED;
+        } else{return OPEN;}
+    }
+
+
+}

--- a/src/main/java/kahlua/KahluaProject/vo/TicketInfoData.java
+++ b/src/main/java/kahlua/KahluaProject/vo/TicketInfoData.java
@@ -13,6 +13,9 @@ public record TicketInfoData(
         @Schema(description = "공연 제목", example = "2024년 3월 정기 공연")
         String title,
 
+        @Schema(description = "공연 설명", example="#스물다섯_스물하나 #데이식스 #잔나비 #YB밴드 #백예린 #미도와_파라솔 ")
+        String content,
+
         @Schema(description = "장소", example = "001 클럽")
         String venue,
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #136, close #138
 

## 📝작업 내용

> 공연리스트를 조회하는 API, 공연 상세 정보를 조회하는 API 구현

이때, 공연 설명도 같이 조회해야해서 ticket_info_data에 content 필드를 추가하였다

### 스크린샷 (선택)
<img width="718" alt="image" src="https://github.com/user-attachments/assets/045f7679-bc39-4bc6-8611-2508f4e873a7" />
<img width="710" alt="image" src="https://github.com/user-attachments/assets/cdbe4d28-8957-47e5-ac62-58d50fa090b5" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


