### PR TITLE
Feature: 공연생성 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,10 @@ dependencies {
 
 	//Webflux
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	//netty
+	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.100.Final:osx-aarch_64'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/kahlua/KahluaProject/controller/PerformanceController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/PerformanceController.java
@@ -3,10 +3,19 @@ package kahlua.KahluaProject.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kahlua.KahluaProject.apipayload.ApiResponse;
+import kahlua.KahluaProject.domain.ticketInfo.TicketInfo;
+import kahlua.KahluaProject.dto.post.request.PostCreateRequest;
+import kahlua.KahluaProject.dto.post.response.PostCreateResponse;
+import kahlua.KahluaProject.dto.ticket.request.TicketCreateRequest;
+import kahlua.KahluaProject.dto.ticket.response.TicketCreateResponse;
+import kahlua.KahluaProject.dto.ticketInfo.request.TicketInfoRequest;
 import kahlua.KahluaProject.dto.ticketInfo.response.PerformanceRes;
 import kahlua.KahluaProject.dto.ticketInfo.response.TicketInfoResponse;
+import kahlua.KahluaProject.security.AuthDetails;
 import kahlua.KahluaProject.service.PerformanceService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "공연 페이지", description = "공연페이지 관련 API")
@@ -28,6 +37,13 @@ public class PerformanceController {
     @Operation(summary = "공연 상세정보 조회 API", description = "특정 공연의 상세정보를 조회하는 API입니다.")
     public ApiResponse<PerformanceRes.performanceInfoDto> getPerformanceInfo(@PathVariable Long ticketInfoId){
         return ApiResponse.onSuccess(performanceService.getPerformanceInfo(ticketInfoId));
+    }
+
+    @PostMapping("/create")
+    @Operation(summary = "공연정보 생성 API", description = "새로운 공연을 생성하는 API입니다.")
+    public ApiResponse<TicketInfoResponse> createPerformance(@RequestBody TicketInfoRequest ticketCreateRequest, @AuthenticationPrincipal AuthDetails authDetails){
+        TicketInfoResponse ticketinfoResponse = performanceService.createPerformance(ticketCreateRequest, authDetails.user());
+        return ApiResponse.onSuccess(ticketinfoResponse);
     }
 }
 

--- a/src/main/java/kahlua/KahluaProject/converter/TicketConverter.java
+++ b/src/main/java/kahlua/KahluaProject/converter/TicketConverter.java
@@ -86,37 +86,4 @@ public class TicketConverter {
                 .status(ticket.getStatus())
                 .build();
     }
-
-    public static TicketInfoData toTicketInfo(TicketInfoRequest ticketInfoRequest) {
-        return TicketInfoData.builder()
-                .title(ticketInfoRequest.title())
-                .venue(ticketInfoRequest.venue())
-                .address(ticketInfoRequest.address())
-                .dateTime(ticketInfoRequest.dateTime())
-                .freshmanPrice(ticketInfoRequest.freshmanPrice())
-                .freshmanMaxPurchase(ticketInfoRequest.freshmanMaxPurchase())
-                .generalPrice(ticketInfoRequest.generalPrice())
-                .generalMaxPurchase(ticketInfoRequest.generalMaxPurchase())
-                .bookingStartDate(ticketInfoRequest.bookingStartDate())
-                .bookingEndDate(ticketInfoRequest.bookingEndDate())
-                .build();
-    }
-
-    public static TicketInfoResponse toTicketInfoResponse(TicketInfo ticketInfo) {
-        return TicketInfoResponse.builder()
-                .id(ticketInfo.getId())
-                .posterImageUrl(ticketInfo.getPosterImageUrl())
-                .title(ticketInfo.getTicketInfoData().title())
-                .content(ticketInfo.getTicketInfoData().content())
-                .venue(ticketInfo.getTicketInfoData().venue())
-                .address(ticketInfo.getTicketInfoData().address())
-                .dateTime(ticketInfo.getTicketInfoData().dateTime())
-                .freshmanPrice(ticketInfo.getTicketInfoData().freshmanPrice())
-                .freshmanMaxPurchase(ticketInfo.getTicketInfoData().freshmanMaxPurchase())
-                .generalPrice(ticketInfo.getTicketInfoData().generalPrice())
-                .generalMaxPurchase(ticketInfo.getTicketInfoData().generalMaxPurchase())
-                .bookingStartDate(ticketInfo.getTicketInfoData().bookingStartDate())
-                .bookingEndDate(ticketInfo.getTicketInfoData().bookingEndDate())
-                .build();
-    }
 }

--- a/src/main/java/kahlua/KahluaProject/converter/TicketInfoConverter.java
+++ b/src/main/java/kahlua/KahluaProject/converter/TicketInfoConverter.java
@@ -19,42 +19,37 @@ public class TicketInfoConverter {
                 .build();
     }
 
-    public static TicketInfo toCreateTicketInfo(TicketInfoRequest request) {
-        TicketInfoData ticketInfoData = new TicketInfoData(
-                request.title(),
-                request.content(),
-                request.venue(),
-                request.address(),
-                request.dateTime(),
-                request.freshmanPrice(),
-                request.freshmanMaxPurchase(),
-                request.generalPrice(),
-                request.generalMaxPurchase(),
-                request.bookingStartDate(),
-                request.bookingEndDate()
-        );
-        return TicketInfo.builder()
-                .posterImageUrl(request.posterImageUrl())
-                .ticketInfoData(ticketInfoData)
+    public static TicketInfoData toTicketInfo(TicketInfoRequest ticketInfoRequest) {
+        return TicketInfoData.builder()
+                .title(ticketInfoRequest.title())
+                .content(ticketInfoRequest.content())
+                .venue(ticketInfoRequest.venue())
+                .address(ticketInfoRequest.address())
+                .dateTime(ticketInfoRequest.dateTime())
+                .freshmanPrice(ticketInfoRequest.freshmanPrice())
+                .freshmanMaxPurchase(ticketInfoRequest.freshmanMaxPurchase())
+                .generalPrice(ticketInfoRequest.generalPrice())
+                .generalMaxPurchase(ticketInfoRequest.generalMaxPurchase())
+                .bookingStartDate(ticketInfoRequest.bookingStartDate())
+                .bookingEndDate(ticketInfoRequest.bookingEndDate())
                 .build();
     }
 
-    public static TicketInfoResponse toCreateTicketInfoResponse(TicketInfo ticketInfo) {
-        TicketInfoData data = ticketInfo.getTicketInfoData();
+    public static TicketInfoResponse toTicketInfoResponse(TicketInfo ticketInfo) {
         return TicketInfoResponse.builder()
                 .id(ticketInfo.getId())
                 .posterImageUrl(ticketInfo.getPosterImageUrl())
-                .title(data.title())
-                .content(data.content())
-                .venue(data.venue())
-                .address(data.address())
-                .dateTime(data.dateTime())
-                .freshmanPrice(data.freshmanPrice())
-                .freshmanMaxPurchase(data.freshmanMaxPurchase())
-                .generalPrice(data.generalPrice())
-                .generalMaxPurchase(data.generalMaxPurchase())
-                .bookingStartDate(data.bookingStartDate())
-                .bookingEndDate(data.bookingEndDate())
+                .title(ticketInfo.getTicketInfoData().title())
+                .content(ticketInfo.getTicketInfoData().content())
+                .venue(ticketInfo.getTicketInfoData().venue())
+                .address(ticketInfo.getTicketInfoData().address())
+                .dateTime(ticketInfo.getTicketInfoData().dateTime())
+                .freshmanPrice(ticketInfo.getTicketInfoData().freshmanPrice())
+                .freshmanMaxPurchase(ticketInfo.getTicketInfoData().freshmanMaxPurchase())
+                .generalPrice(ticketInfo.getTicketInfoData().generalPrice())
+                .generalMaxPurchase(ticketInfo.getTicketInfoData().generalMaxPurchase())
+                .bookingStartDate(ticketInfo.getTicketInfoData().bookingStartDate())
+                .bookingEndDate(ticketInfo.getTicketInfoData().bookingEndDate())
                 .build();
     }
 }

--- a/src/main/java/kahlua/KahluaProject/converter/TicketInfoConverter.java
+++ b/src/main/java/kahlua/KahluaProject/converter/TicketInfoConverter.java
@@ -2,16 +2,14 @@ package kahlua.KahluaProject.converter;
 
 import kahlua.KahluaProject.domain.ticketInfo.PerformanceStatus;
 import kahlua.KahluaProject.domain.ticketInfo.TicketInfo;
+import kahlua.KahluaProject.dto.ticketInfo.request.TicketInfoRequest;
 import kahlua.KahluaProject.dto.ticketInfo.response.PerformanceRes;
-
-import java.time.LocalDateTime;
-
-import static kahlua.KahluaProject.domain.ticketInfo.PerformanceStatus.CLOSED;
-import static kahlua.KahluaProject.domain.ticketInfo.PerformanceStatus.OPEN;
+import kahlua.KahluaProject.dto.ticketInfo.response.TicketInfoResponse;
+import kahlua.KahluaProject.vo.TicketInfoData;
 
 public class TicketInfoConverter {
 
-    public static PerformanceRes.performanceDto toPerformanceDto(TicketInfo info,PerformanceStatus status){
+    public static PerformanceRes.performanceDto toPerformanceDto(TicketInfo info, PerformanceStatus status){
         return PerformanceRes.performanceDto.builder()
                 .ticketInfoId(info.getId())
                 .title(info.getTicketInfoData().title())
@@ -21,4 +19,42 @@ public class TicketInfoConverter {
                 .build();
     }
 
+    public static TicketInfo toCreateTicketInfo(TicketInfoRequest request) {
+        TicketInfoData ticketInfoData = new TicketInfoData(
+                request.title(),
+                request.content(),
+                request.venue(),
+                request.address(),
+                request.dateTime(),
+                request.freshmanPrice(),
+                request.freshmanMaxPurchase(),
+                request.generalPrice(),
+                request.generalMaxPurchase(),
+                request.bookingStartDate(),
+                request.bookingEndDate()
+        );
+        return TicketInfo.builder()
+                .posterImageUrl(request.posterImageUrl())
+                .ticketInfoData(ticketInfoData)
+                .build();
+    }
+
+    public static TicketInfoResponse toCreateTicketInfoResponse(TicketInfo ticketInfo) {
+        TicketInfoData data = ticketInfo.getTicketInfoData();
+        return TicketInfoResponse.builder()
+                .id(ticketInfo.getId())
+                .posterImageUrl(ticketInfo.getPosterImageUrl())
+                .title(data.title())
+                .content(data.content())
+                .venue(data.venue())
+                .address(data.address())
+                .dateTime(data.dateTime())
+                .freshmanPrice(data.freshmanPrice())
+                .freshmanMaxPurchase(data.freshmanMaxPurchase())
+                .generalPrice(data.generalPrice())
+                .generalMaxPurchase(data.generalMaxPurchase())
+                .bookingStartDate(data.bookingStartDate())
+                .bookingEndDate(data.bookingEndDate())
+                .build();
+    }
 }

--- a/src/main/java/kahlua/KahluaProject/domain/ticketInfo/TicketInfo.java
+++ b/src/main/java/kahlua/KahluaProject/domain/ticketInfo/TicketInfo.java
@@ -26,6 +26,13 @@ public class TicketInfo extends BaseEntity {
     @JdbcTypeCode(SqlTypes.JSON)
     private TicketInfoData ticketInfoData;
 
+    public static TicketInfo create(String posterImageUrl, TicketInfoData ticketInfoData) {
+        return TicketInfo.builder()
+                .posterImageUrl(posterImageUrl)
+                .ticketInfoData(ticketInfoData)
+                .build();
+    }
+
     public void update(String posterImageUrl, TicketInfoData ticketInfoData) {
         this.posterImageUrl = posterImageUrl;
         this.ticketInfoData =ticketInfoData;

--- a/src/main/java/kahlua/KahluaProject/dto/ticketInfo/request/TicketInfoRequest.java
+++ b/src/main/java/kahlua/KahluaProject/dto/ticketInfo/request/TicketInfoRequest.java
@@ -11,6 +11,9 @@ public record TicketInfoRequest(
         @Schema(description = "공연 제목", example = "2024년 3월 정기 공연")
         String title,
 
+        @Schema(description = "공연 설명", example="#스물다섯_스물하나 #데이식스 #잔나비 #YB밴드 #백예린 #미도와_파라솔")
+        String content,
+
         @Schema(description = "장소", example = "001 클럽")
         String venue,
 

--- a/src/main/java/kahlua/KahluaProject/service/PerformanceService.java
+++ b/src/main/java/kahlua/KahluaProject/service/PerformanceService.java
@@ -20,6 +20,7 @@ import kahlua.KahluaProject.dto.ticketInfo.response.PerformanceRes;
 import kahlua.KahluaProject.dto.ticketInfo.response.TicketInfoResponse;
 import kahlua.KahluaProject.exception.GeneralException;
 import kahlua.KahluaProject.repository.ticket.TicketInfoRepository;
+import kahlua.KahluaProject.vo.TicketInfoData;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -83,7 +84,7 @@ public class PerformanceService {
                 .orElseThrow(()->new GeneralException(ErrorStatus.TICKETINFO_NOT_FOUND));
 
         return PerformanceRes.performanceInfoDto.builder()
-                .ticketInfoResponse(TicketConverter.toTicketInfoResponse(ticketInfo))
+                .ticketInfoResponse(TicketInfoConverter.toTicketInfoResponse(ticketInfo))
                 .status(checkStatus(ticketInfo))
                 .build();
     }
@@ -92,9 +93,10 @@ public class PerformanceService {
         if(user.getUserType() != UserType.ADMIN) {
             throw new GeneralException(ErrorStatus.UNAUTHORIZED);
         }
-        TicketInfo ticketInfo = TicketInfoConverter.toCreateTicketInfo(request);
+        String posterImageUrl = request.posterImageUrl();
+        TicketInfoData ticketInfoData = TicketInfoConverter.toTicketInfo(request);
+        TicketInfo ticketInfo = TicketInfo.create(posterImageUrl, ticketInfoData);
         ticketInfoRepository.save(ticketInfo);
-
-        return TicketInfoConverter.toCreateTicketInfoResponse(ticketInfo);
+        return TicketInfoConverter.toTicketInfoResponse(ticketInfo);
     }
 }

--- a/src/main/java/kahlua/KahluaProject/service/PerformanceService.java
+++ b/src/main/java/kahlua/KahluaProject/service/PerformanceService.java
@@ -1,10 +1,21 @@
 package kahlua.KahluaProject.service;
 
+import jakarta.transaction.Transactional;
 import kahlua.KahluaProject.apipayload.code.status.ErrorStatus;
+import kahlua.KahluaProject.converter.PostConverter;
 import kahlua.KahluaProject.converter.TicketConverter;
 import kahlua.KahluaProject.converter.TicketInfoConverter;
+import kahlua.KahluaProject.domain.post.Post;
+import kahlua.KahluaProject.domain.post.PostImage;
+import kahlua.KahluaProject.domain.ticket.Ticket;
 import kahlua.KahluaProject.domain.ticketInfo.PerformanceStatus;
 import kahlua.KahluaProject.domain.ticketInfo.TicketInfo;
+import kahlua.KahluaProject.domain.user.User;
+import kahlua.KahluaProject.domain.user.UserType;
+import kahlua.KahluaProject.dto.post.request.PostCreateRequest;
+import kahlua.KahluaProject.dto.post.response.PostCreateResponse;
+import kahlua.KahluaProject.dto.post.response.PostImageCreateResponse;
+import kahlua.KahluaProject.dto.ticketInfo.request.TicketInfoRequest;
 import kahlua.KahluaProject.dto.ticketInfo.response.PerformanceRes;
 import kahlua.KahluaProject.dto.ticketInfo.response.TicketInfoResponse;
 import kahlua.KahluaProject.exception.GeneralException;
@@ -19,6 +30,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static kahlua.KahluaProject.domain.post.PostType.KAHLUA_TIME;
+import static kahlua.KahluaProject.domain.post.PostType.NOTICE;
 import static kahlua.KahluaProject.domain.ticketInfo.PerformanceStatus.CLOSED;
 import static kahlua.KahluaProject.domain.ticketInfo.PerformanceStatus.OPEN;
 
@@ -75,4 +88,13 @@ public class PerformanceService {
                 .build();
     }
 
+    public TicketInfoResponse createPerformance(TicketInfoRequest request, User user) {
+        if(user.getUserType() != UserType.ADMIN) {
+            throw new GeneralException(ErrorStatus.UNAUTHORIZED);
+        }
+        TicketInfo ticketInfo = TicketInfoConverter.toCreateTicketInfo(request);
+        ticketInfoRepository.save(ticketInfo);
+
+        return TicketInfoConverter.toCreateTicketInfoResponse(ticketInfo);
+    }
 }

--- a/src/main/java/kahlua/KahluaProject/service/TicketService.java
+++ b/src/main/java/kahlua/KahluaProject/service/TicketService.java
@@ -3,6 +3,7 @@ package kahlua.KahluaProject.service;
 import jakarta.transaction.Transactional;
 import kahlua.KahluaProject.apipayload.code.status.ErrorStatus;
 import kahlua.KahluaProject.converter.TicketConverter;
+import kahlua.KahluaProject.converter.TicketInfoConverter;
 import kahlua.KahluaProject.domain.ticket.Participants;
 import kahlua.KahluaProject.domain.ticket.Status;
 import kahlua.KahluaProject.domain.ticketInfo.TicketInfo;
@@ -364,13 +365,13 @@ public class TicketService {
 
         //business logic: ticket 정보 수정
         String posterImageUrl = ticketUpdateRequest.posterImageUrl();
-        TicketInfoData ticketInfoData = TicketConverter.toTicketInfo(ticketUpdateRequest);
+        TicketInfoData ticketInfoData = TicketInfoConverter.toTicketInfo(ticketUpdateRequest);
         ticketInfo.update(posterImageUrl, ticketInfoData);
 
         TicketInfo updatedTicketInfo = ticketInfoRepository.save(ticketInfo);
 
         //return: 수정된 ticket 정보 반환
-        return TicketConverter.toTicketInfoResponse(updatedTicketInfo);
+        return TicketInfoConverter.toTicketInfoResponse(updatedTicketInfo);
     }
 
     public TicketInfoResponse getTicketInfo(Long ticketInfoId) {
@@ -379,7 +380,7 @@ public class TicketService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.TICKET_NOT_FOUND));
 
         //return: ticket 정보 반환
-        return TicketConverter.toTicketInfoResponse(ticketInfo);
+        return TicketInfoConverter.toTicketInfoResponse(ticketInfo);
     }
 
     public TicketStatisticsResponse getTicketStatistics(User user) {


### PR DESCRIPTION
## #️⃣연관된 이슈
#139  

### 스크린샷 (선택)
![스크린샷 2025-02-15 오전 12 40 32](https://github.com/user-attachments/assets/723c676a-6353-402d-b5aa-45b2ac26801d)
![스크린샷 2025-02-15 오전 12 40 26](https://github.com/user-attachments/assets/d1be1815-4d64-4554-96f8-d06b430eb5ec)

## 💬리뷰 요구사항(선택)
추후 TicketInfo는 전부 PerformanceInfo로 리팩하고..
우리 사이트에 `공연중`, `예매가능` 둘 다 있으니 PerformanceStatus=OPEN인 놈들에 한해서만 BookStatus를 만들어 예매가능기간 입력받는게 좋을거같아요
