### PR TITLE
feat: TicketInfo에 공연 영상 링크 필드 추가 (#142)

### DIFF
--- a/src/main/java/kahlua/KahluaProject/converter/TicketConverter.java
+++ b/src/main/java/kahlua/KahluaProject/converter/TicketConverter.java
@@ -106,6 +106,7 @@ public class TicketConverter {
         return TicketInfoResponse.builder()
                 .id(ticketInfo.getId())
                 .posterImageUrl(ticketInfo.getPosterImageUrl())
+                .youtubeUrl(ticketInfo.getYoutubeUrl())
                 .title(ticketInfo.getTicketInfoData().title())
                 .content(ticketInfo.getTicketInfoData().content())
                 .venue(ticketInfo.getTicketInfoData().venue())

--- a/src/main/java/kahlua/KahluaProject/domain/ticketInfo/TicketInfo.java
+++ b/src/main/java/kahlua/KahluaProject/domain/ticketInfo/TicketInfo.java
@@ -22,7 +22,7 @@ public class TicketInfo extends BaseEntity {
     @Column(nullable = false, columnDefinition = "text")
     private String posterImageUrl;
 
-    @Column(nullable = false, columnDefinition = "text")
+    @Column(nullable = true, columnDefinition = "text")
     private String youtubeUrl;
 
     @Column(columnDefinition = "json")

--- a/src/main/java/kahlua/KahluaProject/domain/ticketInfo/TicketInfo.java
+++ b/src/main/java/kahlua/KahluaProject/domain/ticketInfo/TicketInfo.java
@@ -22,6 +22,9 @@ public class TicketInfo extends BaseEntity {
     @Column(nullable = false, columnDefinition = "text")
     private String posterImageUrl;
 
+    @Column(nullable = false, columnDefinition = "text")
+    private String youtubeUrl;
+
     @Column(columnDefinition = "json")
     @JdbcTypeCode(SqlTypes.JSON)
     private TicketInfoData ticketInfoData;

--- a/src/main/java/kahlua/KahluaProject/dto/ticketInfo/request/TicketInfoRequest.java
+++ b/src/main/java/kahlua/KahluaProject/dto/ticketInfo/request/TicketInfoRequest.java
@@ -8,6 +8,9 @@ public record TicketInfoRequest(
         @Schema(description = "공연 포스터 이미지", example = "https://kahlua.com/1.jpg")
         String posterImageUrl,
 
+        @Schema(description = "공연 영성 링크", example = "https://youtu.be/QaGbEsecSVE?si=2g2krmBXw1qQZcaW")
+        String youtubeUrl,
+
         @Schema(description = "공연 제목", example = "2024년 3월 정기 공연")
         String title,
 

--- a/src/main/java/kahlua/KahluaProject/dto/ticketInfo/response/PerformanceRes.java
+++ b/src/main/java/kahlua/KahluaProject/dto/ticketInfo/response/PerformanceRes.java
@@ -48,6 +48,7 @@ public class PerformanceRes {
     @AllArgsConstructor
     public static class performanceInfoDto{
         TicketInfoResponse ticketInfoResponse;
+
         @Schema(description = "공연 상태")
         PerformanceStatus status;
     }

--- a/src/main/java/kahlua/KahluaProject/dto/ticketInfo/response/TicketInfoResponse.java
+++ b/src/main/java/kahlua/KahluaProject/dto/ticketInfo/response/TicketInfoResponse.java
@@ -17,6 +17,9 @@ public record TicketInfoResponse(
         @Schema(description = "공연 포스터 이미지", example = "https://kahlua.com/1.jpg")
         String posterImageUrl,
 
+        @Schema(description = "공연 영상 링크", example = "https://youtu.be/QaGbEsecSVE?si=2g2krmBXw1qQZcaW")
+        String youtubeUrl,
+
         @Schema(description = "공연 제목", example = "2024년 3월 정기 공연")
         String title,
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #142 

## 📝작업 내용

> TicketInfo 테이블에 youtubeUrl(공연 영상 링크) 필드를 추가하였다

### 스크린샷 (선택)
<img width="720" alt="image" src="https://github.com/user-attachments/assets/443a1f72-5f8c-4f32-9eaa-2cf63d9702bc" />


## 💬리뷰 요구사항(선택)

