### PR TITLE
fix: 공연날짜 최신순으로 변경 & 커서 에러 해결 (#147)

### DIFF
--- a/src/main/java/kahlua/KahluaProject/repository/ticket/TicketInfoRepository/TicketInfoCustomRepository.java
+++ b/src/main/java/kahlua/KahluaProject/repository/ticket/TicketInfoRepository/TicketInfoCustomRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface TicketInfoCustomRepository {
     List<TicketInfo> findTicketInfos(int limit);
 
-    List<TicketInfo> findTicketInfosByDateTime(LocalDateTime dateTime, int limit);
+    List<TicketInfo> findTicketInfosOrderByDateTime(LocalDateTime dateTime, int limit);
 }

--- a/src/main/java/kahlua/KahluaProject/repository/ticket/TicketInfoRepository/TicketInfoCustomRepositoryImpl.java
+++ b/src/main/java/kahlua/KahluaProject/repository/ticket/TicketInfoRepository/TicketInfoCustomRepositoryImpl.java
@@ -1,14 +1,13 @@
 package kahlua.KahluaProject.repository.ticket.TicketInfoRepository;
 
+import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import kahlua.KahluaProject.domain.ticketInfo.TicketInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static kahlua.KahluaProject.domain.ticketInfo.QTicketInfo.ticketInfo;
@@ -17,7 +16,6 @@ import static kahlua.KahluaProject.domain.ticketInfo.QTicketInfo.ticketInfo;
 @Repository
 @RequiredArgsConstructor
 public class TicketInfoCustomRepositoryImpl implements TicketInfoCustomRepository {
-
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
@@ -25,7 +23,7 @@ public class TicketInfoCustomRepositoryImpl implements TicketInfoCustomRepositor
         return jpaQueryFactory
                 .selectFrom(ticketInfo)
                 .orderBy(
-                        Expressions.stringTemplate("JSON_UNQUOTE(JSON_EXTRACT({0}, '$.dateTime'))", ticketInfo.ticketInfoData)
+                        Expressions.stringTemplate("JSON_UNQUOTE(JSON_EXTRACT({0}, '$.date_time'))", ticketInfo.ticketInfoData)
                                 .desc()
                 )
                 .limit(limit)
@@ -33,18 +31,35 @@ public class TicketInfoCustomRepositoryImpl implements TicketInfoCustomRepositor
     }
 
     @Override
-    public List<TicketInfo> findTicketInfosByDateTime(LocalDateTime dateTime, int limit) {
+    public List<TicketInfo> findTicketInfosOrderByDateTime(LocalDateTime cursorDateTime, int limit) {
+        DateTimeExpression<LocalDateTime> dbDateTimeExpr = Expressions.dateTimeTemplate(
+                LocalDateTime.class,
+                "STR_TO_DATE(CONCAT("
+                        + "CONCAT('', JSON_UNQUOTE(JSON_EXTRACT({0}, '$.date_time[0]'))), '-',"
+                        + "LPAD(CONCAT('', JSON_UNQUOTE(JSON_EXTRACT({0}, '$.date_time[1]'))), 2, '0'), '-',"
+                        + "LPAD(CONCAT('', JSON_UNQUOTE(JSON_EXTRACT({0}, '$.date_time[2]'))), 2, '0'), ' ',"
+                        + "LPAD(CONCAT('', JSON_UNQUOTE(JSON_EXTRACT({0}, '$.date_time[3]'))), 2, '0'), ':',"
+                        + "LPAD(CONCAT('', JSON_UNQUOTE(JSON_EXTRACT({0}, '$.date_time[4]'))), 2, '0'), ':',"
+                        + "LPAD(CONCAT('', JSON_UNQUOTE(JSON_EXTRACT({0}, '$.date_time[5]'))), 2, '0')"
+                        + "), '%Y-%m-%d %H:%i:%s')",
+                ticketInfo.ticketInfoData
+        );
+
+        String cursorFormatted = cursorDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+
+        DateTimeExpression<LocalDateTime> cursorDateTimeExpr = Expressions.dateTimeTemplate(
+                LocalDateTime.class,
+                "STR_TO_DATE({0}, '%Y-%m-%d %H:%i:%s')",
+                Expressions.constant(cursorFormatted)
+        );
+
+        //cursorDateTime보다 과거, 최신순, 페이징
         return jpaQueryFactory
                 .selectFrom(ticketInfo)
-                .where(
-                        Expressions.stringTemplate("JSON_UNQUOTE(JSON_EXTRACT({0}, '$.dateTime'))", ticketInfo.ticketInfoData)
-                                .lt(dateTime.toString())
-                )
-                .orderBy(
-                        Expressions.stringTemplate("JSON_UNQUOTE(JSON_EXTRACT({0}, '$.dateTime'))", ticketInfo.ticketInfoData)
-                                .desc()
-                )
+                .where(dbDateTimeExpr.lt(cursorDateTimeExpr))
+                .orderBy(dbDateTimeExpr.desc())
                 .limit(limit)
                 .fetch();
     }
+
 }

--- a/src/main/java/kahlua/KahluaProject/service/PerformanceService.java
+++ b/src/main/java/kahlua/KahluaProject/service/PerformanceService.java
@@ -30,15 +30,14 @@ public class PerformanceService {
     public PerformanceRes.performanceListDto getPerformances(Long cursor, int limit){
 
         List<TicketInfo> ticketInfos;
-        if (cursor == null) {
+        if (cursor == null || cursor == 0) {
             ticketInfos = ticketInfoRepository.findTicketInfos(limit+1);
         } else {
             TicketInfo cursorTicketInfo= ticketInfoRepository.findById(cursor)
                     .orElseThrow(()->new GeneralException(ErrorStatus.TICKETINFO_NOT_FOUND));
             LocalDateTime cursorDateTime=cursorTicketInfo.getTicketInfoData().dateTime();
-            ticketInfos = ticketInfoRepository.findTicketInfosByDateTime(cursorDateTime, limit+1);
+            ticketInfos = ticketInfoRepository.findTicketInfosOrderByDateTime(cursorDateTime, limit+1);
         }
-
 
         Long nextCursor = null;
         boolean hasNext= ticketInfos.size() > limit;


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #147

## 📝작업 내용

공연리스트 조회 시, 최신순 정렬이 안되어있고 커서 입력 시, null이 반한되는 에러를 해결했습니다
지난번에 테스트할 때 대충했는지 이런 결과를 초래했네요.. 앞으로 더 꼼꼼히 하겠습니다 반성합니다...

지금은 로직이 너무 복잡한데, 이후에 공연 끝나고 리팩토링할 때 깔끔하게 해보겠습니다아

### 스크린샷 (선택)
<img width="967" alt="image" src="https://github.com/user-attachments/assets/7ef703a6-766b-4ddf-91cf-7354da77c25c" />
cursor 잘 되는 거 확인

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

