### PR TITLE
Feature: 공연 삭제 API & 유저 타입 검증 로직

### DIFF
--- a/src/main/java/kahlua/KahluaProject/controller/PerformanceController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/PerformanceController.java
@@ -39,5 +39,13 @@ public class PerformanceController {
         PerformanceResponse ticketinfoResponse = performanceService.createPerformance(ticketCreateRequest, authDetails.user());
         return ApiResponse.onSuccess(ticketinfoResponse);
     }
+
+    @DeleteMapping("/{performanceId}")
+    @Operation(summary = "공연 삭제 API", description = "공연을 삭제하는 API입니다.")
+    public ApiResponse<Void> deletePerformance(@PathVariable Long performanceId,@AuthenticationPrincipal AuthDetails authDetails){
+        performanceService.deletePerformance(performanceId, authDetails);
+
+        return ApiResponse.onSuccess(null);
+    }
 }
 

--- a/src/main/java/kahlua/KahluaProject/controller/PerformanceController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/PerformanceController.java
@@ -2,6 +2,8 @@ package kahlua.KahluaProject.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import kahlua.KahluaProject.domain.user.UserType;
+import kahlua.KahluaProject.global.aop.checkAdmin.CheckUserType;
 import kahlua.KahluaProject.global.apipayload.ApiResponse;
 import kahlua.KahluaProject.dto.performance.request.PerformanceRequest;
 import kahlua.KahluaProject.dto.performance.response.PerformanceListResponse;
@@ -33,17 +35,19 @@ public class PerformanceController {
         return ApiResponse.onSuccess(performanceService.getPerformanceInfo(performance_id));
     }
 
+    @CheckUserType(userType = UserType.ADMIN)
     @PostMapping("/create")
     @Operation(summary = "공연정보 생성 API", description = "새로운 공연을 생성하는 API입니다.")
     public ApiResponse<PerformanceResponse> createPerformance(@RequestBody PerformanceRequest ticketCreateRequest, @AuthenticationPrincipal AuthDetails authDetails){
-        PerformanceResponse ticketinfoResponse = performanceService.createPerformance(ticketCreateRequest, authDetails.user());
+        PerformanceResponse ticketinfoResponse = performanceService.createPerformance(ticketCreateRequest);
         return ApiResponse.onSuccess(ticketinfoResponse);
     }
 
+    @CheckUserType(userType = UserType.ADMIN)
     @DeleteMapping("/{performanceId}")
     @Operation(summary = "공연 삭제 API", description = "공연을 삭제하는 API입니다.")
     public ApiResponse<Void> deletePerformance(@PathVariable Long performanceId,@AuthenticationPrincipal AuthDetails authDetails){
-        performanceService.deletePerformance(performanceId, authDetails);
+        performanceService.deletePerformance(performanceId);
 
         return ApiResponse.onSuccess(null);
     }

--- a/src/main/java/kahlua/KahluaProject/controller/adminController/AdminApplyController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/adminController/AdminApplyController.java
@@ -39,7 +39,7 @@ public class AdminApplyController {
     @GetMapping("/all")
     @Operation(summary = "지원자 리스트 조회", description = "id 기준으로 정렬된 지원자 리스트를 조회합니다")
     public ApiResponse<ApplyListResponse> getApplyList(@AuthenticationPrincipal AuthDetails authDetails) {
-        ApplyListResponse applyListResponse = applyService.getApplyList(authDetails.user());
+        ApplyListResponse applyListResponse = applyService.getApplyList();
         return ApiResponse.onSuccess(applyListResponse);
     }
 
@@ -56,7 +56,7 @@ public class AdminApplyController {
     @GetMapping
     @Operation(summary = "지원자 리스트 세션별 조회", description = "1지망 -> 2지망 악기 순서로 정렬된 지원자 리스트를 조회합니다")
     public ApiResponse<ApplyListResponse> getApplyListByPreference(@AuthenticationPrincipal AuthDetails authDetails, @RequestParam(name = "preference") Preference preference) {
-        ApplyListResponse applyListResponse = applyService.getApplyListByPreference(authDetails.user(), preference);
+        ApplyListResponse applyListResponse = applyService.getApplyListByPreference(preference);
         return ApiResponse.onSuccess(applyListResponse);
     }
 
@@ -76,7 +76,7 @@ public class AdminApplyController {
     @PutMapping("/info/{apply_info_id}")
     @Operation(summary = "지원 정보 수정", description = "지원 정보를 수정합니다")
     public ApiResponse<ApplyInfoResponse> updateApplyInfo(@PathVariable("apply_info_id") Long applyId, @RequestBody ApplyInfoRequest applyInfoRequest, @AuthenticationPrincipal AuthDetails authDetails) {
-        return ApiResponse.onSuccess(applyService.updateApplyInfo(applyId, applyInfoRequest, authDetails.user()));
+        return ApiResponse.onSuccess(applyService.updateApplyInfo(applyId, applyInfoRequest));
     }
 
     @GetMapping("/info/{apply_info_id}")
@@ -88,7 +88,7 @@ public class AdminApplyController {
     @GetMapping("/statistics")
     @Operation(summary = "지원자 통계 조회", description = "지원자 통계를 조회합니다")
     public ApiResponse<ApplyStatisticsResponse> getApplyStatistics(@AuthenticationPrincipal AuthDetails authDetails) {
-        return ApiResponse.onSuccess(applyService.getApplyStatistics(authDetails.user()));
+        return ApiResponse.onSuccess(applyService.getApplyStatistics());
     }
 }
 

--- a/src/main/java/kahlua/KahluaProject/controller/adminController/AdminApplyController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/adminController/AdminApplyController.java
@@ -2,6 +2,7 @@ package kahlua.KahluaProject.controller.adminController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import kahlua.KahluaProject.global.aop.checkAdmin.CheckUserType;
 import kahlua.KahluaProject.global.apipayload.ApiResponse;
 import kahlua.KahluaProject.global.apipayload.code.status.ErrorStatus;
 import kahlua.KahluaProject.domain.apply.Preference;
@@ -28,6 +29,7 @@ import java.io.IOException;
 @Tag(name = "관리자(지원하기)", description = "관리자(지원하기) 페이지 관련 API")
 @RestController
 @RequiredArgsConstructor
+@CheckUserType(userType = UserType.ADMIN)
 @RequestMapping("/v1/admin/apply")
 public class AdminApplyController {
 

--- a/src/main/java/kahlua/KahluaProject/controller/adminController/AdminTicketController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/adminController/AdminTicketController.java
@@ -2,6 +2,8 @@ package kahlua.KahluaProject.controller.adminController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import kahlua.KahluaProject.domain.user.UserType;
+import kahlua.KahluaProject.global.aop.checkAdmin.CheckUserType;
 import kahlua.KahluaProject.global.apipayload.ApiResponse;
 import kahlua.KahluaProject.dto.ticket.response.TicketListResponse;
 import kahlua.KahluaProject.dto.ticket.response.TicketStatisticsResponse;
@@ -25,6 +27,7 @@ import java.io.IOException;
 @Tag(name = "관리자(예매하기)", description = "관리자(예매하기) 페이지 관련 API")
 @RestController
 @RequiredArgsConstructor
+@CheckUserType(userType = UserType.ADMIN)
 @RequestMapping("/v1/admin/tickets")
 public class AdminTicketController {
 

--- a/src/main/java/kahlua/KahluaProject/controller/adminController/AdminTicketController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/adminController/AdminTicketController.java
@@ -39,7 +39,7 @@ public class AdminTicketController {
             "</br> sort-by를 쿼리에 포함시키지 않은 경우 (환불 요청 -> 결제 대기 -> 결제 왼료 -> 환불 완료) 순서로, 같은 결제 상태에 대해서는 최신순으로 정렬합니다")
     public ApiResponse<TicketListResponse> getTicketList(@AuthenticationPrincipal AuthDetails authDetails,
                                                          @RequestParam(name = "sort-by", required = false) String sortBy) {
-        TicketListResponse ticketListResponse = ticketService.getTicketList(authDetails.user(), sortBy);
+        TicketListResponse ticketListResponse = ticketService.getTicketList(sortBy);
         return ApiResponse.onSuccess(ticketListResponse);
     }
 
@@ -48,7 +48,7 @@ public class AdminTicketController {
             "</br> sort-by를 쿼리에 포함시키지 않은 경우 (환불 요청 -> 결제 대기 -> 결제 왼료 -> 환불 완료) 순서로, 같은 결제 상태에 대해서는 최신순으로 정렬합니다")
     public ApiResponse<TicketListResponse> getGeneralTicketList(@AuthenticationPrincipal AuthDetails authDetails,
                                                                 @RequestParam(name = "sort-by", required = false) String sortBy) {
-        TicketListResponse ticketListResponse = ticketService.getGeneralTicketList(authDetails.user(), sortBy);
+        TicketListResponse ticketListResponse = ticketService.getGeneralTicketList(sortBy);
         return ApiResponse.onSuccess(ticketListResponse);
     }
 
@@ -57,7 +57,7 @@ public class AdminTicketController {
             "</br> sort-by를 쿼리에 포함시키지 않은 경우 (환불 요청 -> 결제 대기 -> 결제 왼료 -> 환불 완료) 순서로, 같은 결제 상태에 대해서는 최신순으로 정렬합니다")
     public ApiResponse<TicketListResponse> getFreshmanTicketList(@AuthenticationPrincipal AuthDetails authDetails,
                                                                  @RequestParam(name = "sort-by", required = false) String sortBy) {
-        TicketListResponse ticketListResponse = ticketService.getFreshmanTicketList(authDetails.user(), sortBy);
+        TicketListResponse ticketListResponse = ticketService.getFreshmanTicketList(sortBy);
         return ApiResponse.onSuccess(ticketListResponse);
     }
 
@@ -65,14 +65,14 @@ public class AdminTicketController {
     @Operation(summary = "티켓 결제 완료", description = "티켓 결제를 완료한 뒤 어드민 페이지에서 결제 완료를 클릭하는 경우 결제 완료로 상태가 변합니다." +
             "</br> 추가적으로 티켓 구매자에게 결제 완료 확인 메일을 발송합니다.")
     public ApiResponse<TicketUpdateResponse> completePaymentForm(@PathVariable(name = "ticketId") Long ticketId, @AuthenticationPrincipal AuthDetails authDetails) {
-        TicketUpdateResponse ticketUpdateResponse = ticketService.completePayment(authDetails.user(), ticketId);
+        TicketUpdateResponse ticketUpdateResponse = ticketService.completePayment(ticketId);
         return ApiResponse.onSuccess(ticketUpdateResponse);
     }
 
     @PatchMapping("/{ticketId}/cancel-complete")
     @Operation(summary = "티켓 취소 완료", description = "티켓 환불을 완료한 뒤 어드민 페이지에서 취소 완료를 클릭하는 경우 취소가 완료로 상태가 변합니다.")
     public ApiResponse<TicketUpdateResponse> completeCancelForm(@PathVariable(name = "ticketId") Long ticketId, @AuthenticationPrincipal AuthDetails authDetails) {
-        TicketUpdateResponse ticketUpdateResponse = ticketService.completeCancelTicket(authDetails.user(), ticketId);
+        TicketUpdateResponse ticketUpdateResponse = ticketService.completeCancelTicket(ticketId);
         return ApiResponse.onSuccess(ticketUpdateResponse);
     }
 
@@ -105,7 +105,7 @@ public class AdminTicketController {
     @PutMapping("/{performance_id}")
     @Operation(summary = "공연 정보 수정", description = "공연 정보를 수정합니다")
     public ApiResponse<PerformanceResponse> updatePerformance(@PathVariable("performance_id") Long performanceId, @RequestBody PerformanceRequest performanceRequest, @AuthenticationPrincipal AuthDetails authDetails) {
-        return ApiResponse.onSuccess(ticketService.updatePerformance(performanceId, performanceRequest, authDetails.user()));
+        return ApiResponse.onSuccess(ticketService.updatePerformance(performanceId, performanceRequest));
     }
 
     @GetMapping("/{performance_id}")
@@ -117,6 +117,6 @@ public class AdminTicketController {
     @GetMapping("/statistics")
     @Operation(summary = "티켓 통계 조회", description = "티켓 통계를 조회합니다")
     public ApiResponse<TicketStatisticsResponse> getTicketStatistics(@AuthenticationPrincipal AuthDetails authDetails) {
-        return ApiResponse.onSuccess(ticketService.getTicketStatistics(authDetails.user()));
+        return ApiResponse.onSuccess(ticketService.getTicketStatistics());
     }
 }

--- a/src/main/java/kahlua/KahluaProject/global/aop/checkAdmin/CheckUserType.java
+++ b/src/main/java/kahlua/KahluaProject/global/aop/checkAdmin/CheckUserType.java
@@ -1,0 +1,14 @@
+package kahlua.KahluaProject.global.aop.checkAdmin;
+
+import kahlua.KahluaProject.domain.user.UserType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckUserType {
+    public UserType userType();
+}

--- a/src/main/java/kahlua/KahluaProject/global/aop/checkAdmin/UserTypeCheckAspect.java
+++ b/src/main/java/kahlua/KahluaProject/global/aop/checkAdmin/UserTypeCheckAspect.java
@@ -1,0 +1,44 @@
+package kahlua.KahluaProject.global.aop.checkAdmin;
+
+import kahlua.KahluaProject.domain.user.User;
+import kahlua.KahluaProject.domain.user.UserType;
+import kahlua.KahluaProject.global.apipayload.code.status.ErrorStatus;
+import kahlua.KahluaProject.global.exception.GeneralException;
+import kahlua.KahluaProject.global.security.AuthDetails;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class UserTypeCheckAspect {
+
+    @Before("@within(checkUserType) || @annotation(checkUserType)")
+    public void checkUserType(JoinPoint joinPoint, CheckUserType checkUserType) {
+        UserType requiredUserType = checkUserType.userType();
+
+        for (Object arg : joinPoint.getArgs()) {
+
+            if (arg instanceof AuthDetails authDetails) {
+                UserType actualType = authDetails.user().getUserType();
+                if (actualType != requiredUserType) {
+                    throw new GeneralException(ErrorStatus.INVALID_USER_TYPE);
+                }
+                return;
+            }
+
+            if (arg instanceof User user) {
+                if (user.getUserType() != requiredUserType) {
+                    throw new GeneralException(ErrorStatus.INVALID_USER_TYPE);
+                }
+                return;
+            }
+        }
+
+        throw new GeneralException(ErrorStatus.UNAUTHORIZED); // 인증 정보 없음
+    }
+
+}

--- a/src/main/java/kahlua/KahluaProject/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/kahlua/KahluaProject/global/apipayload/code/status/ErrorStatus.java
@@ -27,7 +27,7 @@ public enum ErrorStatus implements BaseCode {
     REDIS_NOT_FOUND(HttpStatus.NOT_FOUND, "REDIS_NOT_FOUND", "Redis 설정에 오류가 발생했습니다."),
 
     //유저 에러
-    USER_NOT_ADMIN(HttpStatus.UNAUTHORIZED, "USER_NOT_ADMIN", "ADMIN이 아닙니다."),
+    INVALID_USER_TYPE(HttpStatus.UNAUTHORIZED, "USER_NOT_ADMIN", "요구한 사용자 타입이 아닙니다."),
 
     // 세션 에러
     SESSION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "유효하지 않은 세션입니다."),

--- a/src/main/java/kahlua/KahluaProject/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/kahlua/KahluaProject/global/apipayload/code/status/ErrorStatus.java
@@ -26,6 +26,8 @@ public enum ErrorStatus implements BaseCode {
     ALREADY_EXIST_USER(HttpStatus.BAD_REQUEST, "ALREADY_EXIST_USER", "이미 존재하는 회원입니다."),
     REDIS_NOT_FOUND(HttpStatus.NOT_FOUND, "REDIS_NOT_FOUND", "Redis 설정에 오류가 발생했습니다."),
 
+    //유저 에러
+    USER_NOT_ADMIN(HttpStatus.UNAUTHORIZED, "USER_NOT_ADMIN", "ADMIN이 아닙니다."),
 
     // 세션 에러
     SESSION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "유효하지 않은 세션입니다."),
@@ -54,7 +56,7 @@ public enum ErrorStatus implements BaseCode {
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION_NOT_FOUND", "예약내역을 찾을 수 없습니다."),
 
     //공연 관련 에러
-    TICKETINFO_NOT_FOUND(HttpStatus.NOT_FOUND,"TICKET_INFO<NOT_FOUND","공연 정보를 찾을 수 없습니다."),
+    PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND,"PERFORMANCE_NOT_FOUND","공연 정보를 찾을 수 없습니다."),
 
     ;
 

--- a/src/main/java/kahlua/KahluaProject/service/ApplyService.java
+++ b/src/main/java/kahlua/KahluaProject/service/ApplyService.java
@@ -1,6 +1,7 @@
 package kahlua.KahluaProject.service;
 
 import jakarta.transaction.Transactional;
+import kahlua.KahluaProject.global.aop.checkAdmin.CheckUserType;
 import kahlua.KahluaProject.global.apipayload.code.status.ErrorStatus;
 import kahlua.KahluaProject.converter.ApplyConverter;
 import kahlua.KahluaProject.domain.apply.Apply;
@@ -69,12 +70,8 @@ public class ApplyService {
         return applyAdminGetResponse;
     }
 
+    @CheckUserType(userType = UserType.ADMIN)
     public ApplyListResponse getApplyList(User user) {
-
-        if(user.getUserType() != UserType.ADMIN){
-            throw new GeneralException(ErrorStatus.UNAUTHORIZED);
-        }
-
         List<Apply> applies = applyRepository.findAll();
         List<ApplyItemResponse> applyItemResponses = new ArrayList<>();
         Long total = applyRepository.count();
@@ -103,12 +100,8 @@ public class ApplyService {
         return applyListResponse;
     }
 
+    @CheckUserType(userType = UserType.ADMIN)
     public ApplyListResponse getApplyListByPreference(User user, Preference preference) {
-
-        if(user.getUserType() != UserType.ADMIN){
-            throw new GeneralException(ErrorStatus.UNAUTHORIZED);
-        }
-
         List<Apply> firstPreferenceApplies = applyRepository.findAllByFirstPreference(preference);
         List<Apply> secondPreferenceApplies = applyRepository.findAllBySecondPreference(preference);
 
@@ -154,14 +147,11 @@ public class ApplyService {
         return applyListResponse;
     }
 
+    @CheckUserType(userType = UserType.ADMIN)
     public ApplyInfoResponse updateApplyInfo(Long applyInfoId, ApplyInfoRequest applyInfoRequest, User user) {
         //validation: applyId 유효성, 관리자 권한 확인
         ApplyInfo applyInfo = applyInfoRepository.findById(applyInfoId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.APPLY_INFO_NOT_FOUND));
-
-        if(user.getUserType() != UserType.ADMIN){
-            throw new GeneralException(ErrorStatus.UNAUTHORIZED);
-        }
 
         //business logic: applyInfo 데이터 변환 및 변경사항 업데이트
         ApplyInfoData applyInfodata = ApplyConverter.toApplyInfo(applyInfoRequest);
@@ -184,9 +174,6 @@ public class ApplyService {
 
     public ApplyStatisticsResponse getApplyStatistics(User user) {
         //validation: 관리자 권한 확인
-        if (user.getUserType() != UserType.ADMIN) {
-            throw new GeneralException(ErrorStatus.UNAUTHORIZED);
-        }
 
         //business logic: 전체 지원자 수, 각 세션별 지원자 수 조회
         Long totalApplyCount = applyRepository.countByDeletedAtIsNull()

--- a/src/main/java/kahlua/KahluaProject/service/ApplyService.java
+++ b/src/main/java/kahlua/KahluaProject/service/ApplyService.java
@@ -70,8 +70,7 @@ public class ApplyService {
         return applyAdminGetResponse;
     }
 
-    @CheckUserType(userType = UserType.ADMIN)
-    public ApplyListResponse getApplyList(User user) {
+    public ApplyListResponse getApplyList() {
         List<Apply> applies = applyRepository.findAll();
         List<ApplyItemResponse> applyItemResponses = new ArrayList<>();
         Long total = applyRepository.count();
@@ -100,8 +99,8 @@ public class ApplyService {
         return applyListResponse;
     }
 
-    @CheckUserType(userType = UserType.ADMIN)
-    public ApplyListResponse getApplyListByPreference(User user, Preference preference) {
+
+    public ApplyListResponse getApplyListByPreference(Preference preference) {
         List<Apply> firstPreferenceApplies = applyRepository.findAllByFirstPreference(preference);
         List<Apply> secondPreferenceApplies = applyRepository.findAllBySecondPreference(preference);
 
@@ -148,7 +147,7 @@ public class ApplyService {
     }
 
     @CheckUserType(userType = UserType.ADMIN)
-    public ApplyInfoResponse updateApplyInfo(Long applyInfoId, ApplyInfoRequest applyInfoRequest, User user) {
+    public ApplyInfoResponse updateApplyInfo(Long applyInfoId, ApplyInfoRequest applyInfoRequest) {
         //validation: applyId 유효성, 관리자 권한 확인
         ApplyInfo applyInfo = applyInfoRepository.findById(applyInfoId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.APPLY_INFO_NOT_FOUND));
@@ -172,7 +171,7 @@ public class ApplyService {
         return ApplyConverter.toApplyInfoResponse(applyInfo);
     }
 
-    public ApplyStatisticsResponse getApplyStatistics(User user) {
+    public ApplyStatisticsResponse getApplyStatistics() {
         //validation: 관리자 권한 확인
 
         //business logic: 전체 지원자 수, 각 세션별 지원자 수 조회

--- a/src/main/java/kahlua/KahluaProject/service/PerformanceService.java
+++ b/src/main/java/kahlua/KahluaProject/service/PerformanceService.java
@@ -1,6 +1,7 @@
 package kahlua.KahluaProject.service;
 
 import kahlua.KahluaProject.domain.performance.Performance;
+import kahlua.KahluaProject.global.aop.checkAdmin.CheckAdmin;
 import kahlua.KahluaProject.global.apipayload.code.status.ErrorStatus;
 import kahlua.KahluaProject.converter.PerformanceConverter;
 import kahlua.KahluaProject.domain.performance.PerformanceStatus;
@@ -10,6 +11,7 @@ import kahlua.KahluaProject.dto.performance.request.PerformanceRequest;
 import kahlua.KahluaProject.dto.performance.response.PerformanceListResponse;
 import kahlua.KahluaProject.dto.performance.response.PerformanceResponse;
 import kahlua.KahluaProject.global.exception.GeneralException;
+import kahlua.KahluaProject.global.security.AuthDetails;
 import kahlua.KahluaProject.repository.ticket.PerformanceRepository.PerformanceRepository;
 import kahlua.KahluaProject.vo.PerformanceData;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +36,7 @@ public class PerformanceService {
             performances = performanceRepository.findPerformances(limit+1);
         } else {
             Performance cursorPerformance = performanceRepository.findById(cursor)
-                    .orElseThrow(()->new GeneralException(ErrorStatus.TICKETINFO_NOT_FOUND));
+                    .orElseThrow(()->new GeneralException(ErrorStatus.PERFORMANCE_NOT_FOUND));
             LocalDateTime cursorDateTime= cursorPerformance.getPerformanceData().dateTime();
             performances = performanceRepository.findPerformancesOrderByDateTime(cursorDateTime, limit+1);
         }
@@ -67,7 +69,7 @@ public class PerformanceService {
 
     public PerformanceListResponse.performanceInfoDto getPerformanceInfo(Long ticketInfoId){
         Performance performance = performanceRepository.findById(ticketInfoId)
-                .orElseThrow(()->new GeneralException(ErrorStatus.TICKETINFO_NOT_FOUND));
+                .orElseThrow(()->new GeneralException(ErrorStatus.PERFORMANCE_NOT_FOUND));
 
         return PerformanceListResponse.performanceInfoDto.builder()
                 .performanceResponse(PerformanceConverter.toPerformanceDto(performance))
@@ -85,5 +87,13 @@ public class PerformanceService {
         Performance performance = Performance.create(posterImageUrl, youtubeUrl, performanceData);
         performanceRepository.save(performance);
         return PerformanceConverter.toPerformanceDto(performance);
+    }
+
+    @CheckAdmin
+    public void deletePerformance(Long ticketInfoId, AuthDetails authDetails) {
+        Performance performance=performanceRepository.findById(ticketInfoId)
+                .orElseThrow(()->new GeneralException(ErrorStatus.PERFORMANCE_NOT_FOUND));
+
+        performanceRepository.delete(performance);
     }
 }

--- a/src/main/java/kahlua/KahluaProject/service/PerformanceService.java
+++ b/src/main/java/kahlua/KahluaProject/service/PerformanceService.java
@@ -1,12 +1,10 @@
 package kahlua.KahluaProject.service;
 
 import kahlua.KahluaProject.domain.performance.Performance;
-import kahlua.KahluaProject.global.aop.checkAdmin.CheckAdmin;
+import kahlua.KahluaProject.global.aop.checkAdmin.CheckUserType;
 import kahlua.KahluaProject.global.apipayload.code.status.ErrorStatus;
 import kahlua.KahluaProject.converter.PerformanceConverter;
 import kahlua.KahluaProject.domain.performance.PerformanceStatus;
-import kahlua.KahluaProject.domain.user.User;
-import kahlua.KahluaProject.domain.user.UserType;
 import kahlua.KahluaProject.dto.performance.request.PerformanceRequest;
 import kahlua.KahluaProject.dto.performance.response.PerformanceListResponse;
 import kahlua.KahluaProject.dto.performance.response.PerformanceResponse;
@@ -77,10 +75,9 @@ public class PerformanceService {
                 .build();
     }
 
-    public PerformanceResponse createPerformance(PerformanceRequest request, User user) {
-        if(user.getUserType() != UserType.ADMIN) {
-            throw new GeneralException(ErrorStatus.UNAUTHORIZED);
-        }
+
+    public PerformanceResponse createPerformance(PerformanceRequest request) {
+
         String posterImageUrl = request.posterImageUrl();
         String youtubeUrl = request.youtubeUrl();
         PerformanceData performanceData = PerformanceConverter.toPerformance(request);
@@ -89,8 +86,7 @@ public class PerformanceService {
         return PerformanceConverter.toPerformanceDto(performance);
     }
 
-    @CheckAdmin
-    public void deletePerformance(Long ticketInfoId, AuthDetails authDetails) {
+    public void deletePerformance(Long ticketInfoId) {
         Performance performance=performanceRepository.findById(ticketInfoId)
                 .orElseThrow(()->new GeneralException(ErrorStatus.PERFORMANCE_NOT_FOUND));
 

--- a/src/main/java/kahlua/KahluaProject/service/TicketService.java
+++ b/src/main/java/kahlua/KahluaProject/service/TicketService.java
@@ -74,7 +74,7 @@ public class TicketService {
     //티켓 결제 완료한 경우
     @Transactional
     @CheckUserType(userType = UserType.ADMIN)
-    public TicketUpdateResponse completePayment(User user, Long ticketId) {
+    public TicketUpdateResponse completePayment(Long ticketId) {
 
         Ticket existingTicket = ticketRepository.findById(ticketId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.TICKET_NOT_FOUND));
@@ -106,7 +106,7 @@ public class TicketService {
 
     //티켓 취소 완료
     @Transactional
-    public TicketUpdateResponse completeCancelTicket(User user, Long ticketId) {
+    public TicketUpdateResponse completeCancelTicket(Long ticketId) {
 
         Ticket existingTicket = ticketRepository.findById(ticketId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.TICKET_NOT_FOUND));
@@ -130,7 +130,7 @@ public class TicketService {
     }
 
     // 어드민 페이지 티켓 리스트 조회
-    public TicketListResponse getTicketList(User user, String sortBy) {
+    public TicketListResponse getTicketList(String sortBy) {
         List<Ticket> tickets;
 
         if (sortBy != null) {
@@ -202,7 +202,7 @@ public class TicketService {
     }
 
     // 일반 티켓 리스트 조회
-    public TicketListResponse getGeneralTicketList(User user, String sortBy) {
+    public TicketListResponse getGeneralTicketList(String sortBy) {
 
         List<Ticket> tickets;
 
@@ -252,7 +252,7 @@ public class TicketService {
     }
 
     // 신입생 티켓 리스트 조회
-    public TicketListResponse getFreshmanTicketList(User user, String sortBy) {
+    public TicketListResponse getFreshmanTicketList(String sortBy) {
 
         List<Ticket> tickets;
 
@@ -335,7 +335,7 @@ public class TicketService {
         return total;
     }
 
-    public PerformanceResponse updatePerformance(Long ticketInfoId, PerformanceRequest ticketUpdateRequest, User user) {
+    public PerformanceResponse updatePerformance(Long ticketInfoId, PerformanceRequest ticketUpdateRequest) {
         //validation: ticketId 존재 여부 확인
         Performance performance = performanceRepository.findById(ticketInfoId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.TICKET_NOT_FOUND));
@@ -361,7 +361,7 @@ public class TicketService {
         return PerformanceConverter.toPerformanceDto(performance);
     }
 
-    public TicketStatisticsResponse getTicketStatistics(User user) {
+    public TicketStatisticsResponse getTicketStatistics() {
 
         //business logic: 티켓 통계 조회
         Long totalTicket = ticketRepository.countAllByDeletedAtIsNull()

--- a/src/main/java/kahlua/KahluaProject/service/TicketService.java
+++ b/src/main/java/kahlua/KahluaProject/service/TicketService.java
@@ -2,6 +2,7 @@ package kahlua.KahluaProject.service;
 
 import jakarta.transaction.Transactional;
 import kahlua.KahluaProject.domain.performance.Performance;
+import kahlua.KahluaProject.global.aop.checkAdmin.CheckUserType;
 import kahlua.KahluaProject.global.apipayload.code.status.ErrorStatus;
 import kahlua.KahluaProject.converter.TicketConverter;
 import kahlua.KahluaProject.converter.PerformanceConverter;
@@ -72,11 +73,8 @@ public class TicketService {
 
     //티켓 결제 완료한 경우
     @Transactional
+    @CheckUserType(userType = UserType.ADMIN)
     public TicketUpdateResponse completePayment(User user, Long ticketId) {
-
-        if (user.getUserType() != UserType.ADMIN) {
-            throw new GeneralException(ErrorStatus.UNAUTHORIZED);
-        }
 
         Ticket existingTicket = ticketRepository.findById(ticketId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.TICKET_NOT_FOUND));
@@ -110,10 +108,6 @@ public class TicketService {
     @Transactional
     public TicketUpdateResponse completeCancelTicket(User user, Long ticketId) {
 
-        if (user.getUserType() != UserType.ADMIN) {
-            throw new GeneralException(ErrorStatus.UNAUTHORIZED);
-        }
-
         Ticket existingTicket = ticketRepository.findById(ticketId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.TICKET_NOT_FOUND));
         existingTicket.completeCancel();
@@ -137,11 +131,6 @@ public class TicketService {
 
     // 어드민 페이지 티켓 리스트 조회
     public TicketListResponse getTicketList(User user, String sortBy) {
-
-        if (user.getUserType() != UserType.ADMIN) {
-            throw new GeneralException(ErrorStatus.UNAUTHORIZED);
-        }
-
         List<Ticket> tickets;
 
         if (sortBy != null) {
@@ -215,10 +204,6 @@ public class TicketService {
     // 일반 티켓 리스트 조회
     public TicketListResponse getGeneralTicketList(User user, String sortBy) {
 
-        if (user.getUserType() != UserType.ADMIN) {
-            throw new GeneralException(ErrorStatus.UNAUTHORIZED);
-        }
-
         List<Ticket> tickets;
 
         if (sortBy != null) {
@@ -268,10 +253,6 @@ public class TicketService {
 
     // 신입생 티켓 리스트 조회
     public TicketListResponse getFreshmanTicketList(User user, String sortBy) {
-
-        if (user.getUserType() != UserType.ADMIN) {
-            throw new GeneralException(ErrorStatus.UNAUTHORIZED);
-        }
 
         List<Ticket> tickets;
 
@@ -355,13 +336,9 @@ public class TicketService {
     }
 
     public PerformanceResponse updatePerformance(Long ticketInfoId, PerformanceRequest ticketUpdateRequest, User user) {
-        //validation: ticketId 존재 여부 확인/ user가 admin인지 확인
+        //validation: ticketId 존재 여부 확인
         Performance performance = performanceRepository.findById(ticketInfoId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.TICKET_NOT_FOUND));
-
-        if (user.getUserType() != UserType.ADMIN) {
-            throw new GeneralException(ErrorStatus.UNAUTHORIZED);
-        }
 
         //business logic: ticket 정보 수정
         String posterImageUrl = ticketUpdateRequest.posterImageUrl();
@@ -385,10 +362,6 @@ public class TicketService {
     }
 
     public TicketStatisticsResponse getTicketStatistics(User user) {
-        //validation: user가 admin인지 확인
-        if (user.getUserType() != UserType.ADMIN) {
-            throw new GeneralException(ErrorStatus.UNAUTHORIZED);
-        }
 
         //business logic: 티켓 통계 조회
         Long totalTicket = ticketRepository.countAllByDeletedAtIsNull()


### PR DESCRIPTION
## #️⃣연관된 이슈

close #155

## 📝작업 내용

공연 삭제 API 구현했습니다 따로 반환할 게 없어서 null값으로 했는데, 혹시나 있다면 말씀주세요

그리고 하다보니 유저가 admin인지 검사하는 로직이 중복이 많고, 앞으로도 유저 타입 검증할 일이 많을 거 같아서 AOP 이용해서 하나 만들어뒀습니다 일단 제가 보이는 대로 다 수정해두긴했는데 또 보이면 `@CheckUserType(userType = UserType.[검증하고싶은 역할])` 로 사용하시면 될 거 같습니다

### 스크린샷 (선택)
<img width="708" alt="image" src="https://github.com/user-attachments/assets/346f8ac7-7d99-41a3-b948-613860f9e643" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

관리자 권한 검증 로직 리팩토링할 때 adminController는 클래스에 붙였고, service에는 따로 안 붙였습니다.
구글링할 때 다들 한 곳에만 붙이는데 지피티는 controller, service 두 개 다에 붙이는 게 좋다고 하더라구요 일단 구글링한 대로 해뒀는데 다른 분들 의견이 궁금합니다~~

추가로 service에 검증을 위해 user 넘기던데, 이것도 다 없애는 걸로 수정할까요??
