### PR TITLE
Fix: 유저 타입 검증 로직 수정 (#155)

### DIFF
--- a/src/main/java/kahlua/KahluaProject/controller/adminController/AdminApplyController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/adminController/AdminApplyController.java
@@ -29,13 +29,13 @@ import java.io.IOException;
 @Tag(name = "관리자(지원하기)", description = "관리자(지원하기) 페이지 관련 API")
 @RestController
 @RequiredArgsConstructor
-@CheckUserType(userType = UserType.ADMIN)
 @RequestMapping("/v1/admin/apply")
 public class AdminApplyController {
 
     private final ApplyService applyService;
     private final ExcelConvertService excelConvertService;
 
+    @CheckUserType(userType = UserType.ADMIN)
     @GetMapping("/all")
     @Operation(summary = "지원자 리스트 조회", description = "id 기준으로 정렬된 지원자 리스트를 조회합니다")
     public ApiResponse<ApplyListResponse> getApplyList(@AuthenticationPrincipal AuthDetails authDetails) {
@@ -43,6 +43,7 @@ public class AdminApplyController {
         return ApiResponse.onSuccess(applyListResponse);
     }
 
+    @CheckUserType(userType = UserType.ADMIN)
     @GetMapping("/{applyId}")
     @Operation(summary = "지원자 상세정보 조회", description = "지원자 상세정보를 조회합니다")
     public ApiResponse<ApplyAdminGetResponse> getApplyDetail(@PathVariable Long applyId, @AuthenticationPrincipal AuthDetails authDetails) {
@@ -53,6 +54,7 @@ public class AdminApplyController {
         return ApiResponse.onSuccess(applyAdminGetResponse);
     }
 
+    @CheckUserType(userType = UserType.ADMIN)
     @GetMapping
     @Operation(summary = "지원자 리스트 세션별 조회", description = "1지망 -> 2지망 악기 순서로 정렬된 지원자 리스트를 조회합니다")
     public ApiResponse<ApplyListResponse> getApplyListByPreference(@AuthenticationPrincipal AuthDetails authDetails, @RequestParam(name = "preference") Preference preference) {
@@ -73,6 +75,7 @@ public class AdminApplyController {
                 .body(new InputStreamResource(in));
     }
 
+    @CheckUserType(userType = UserType.ADMIN)
     @PutMapping("/info/{apply_info_id}")
     @Operation(summary = "지원 정보 수정", description = "지원 정보를 수정합니다")
     public ApiResponse<ApplyInfoResponse> updateApplyInfo(@PathVariable("apply_info_id") Long applyId, @RequestBody ApplyInfoRequest applyInfoRequest, @AuthenticationPrincipal AuthDetails authDetails) {
@@ -85,6 +88,7 @@ public class AdminApplyController {
         return ApiResponse.onSuccess(applyService.getApplyInfo(applyId));
     }
 
+    @CheckUserType(userType = UserType.ADMIN)
     @GetMapping("/statistics")
     @Operation(summary = "지원자 통계 조회", description = "지원자 통계를 조회합니다")
     public ApiResponse<ApplyStatisticsResponse> getApplyStatistics(@AuthenticationPrincipal AuthDetails authDetails) {

--- a/src/main/java/kahlua/KahluaProject/controller/adminController/AdminTicketController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/adminController/AdminTicketController.java
@@ -27,13 +27,13 @@ import java.io.IOException;
 @Tag(name = "관리자(예매하기)", description = "관리자(예매하기) 페이지 관련 API")
 @RestController
 @RequiredArgsConstructor
-@CheckUserType(userType = UserType.ADMIN)
 @RequestMapping("/v1/admin/tickets")
 public class AdminTicketController {
 
     private final TicketService ticketService;
     private final ExcelConvertService excelConvertService;
 
+    @CheckUserType(userType = UserType.ADMIN)
     @GetMapping
     @Operation(summary = "전체 티켓 리스트 조회", description = "sort-by에 정의된 티켓 속성 기준으로 정렬된 전체 티켓 리스트를 조회합니다 " +
             "</br> sort-by를 쿼리에 포함시키지 않은 경우 (환불 요청 -> 결제 대기 -> 결제 왼료 -> 환불 완료) 순서로, 같은 결제 상태에 대해서는 최신순으로 정렬합니다")
@@ -43,6 +43,7 @@ public class AdminTicketController {
         return ApiResponse.onSuccess(ticketListResponse);
     }
 
+    @CheckUserType(userType = UserType.ADMIN)
     @GetMapping("/general")
     @Operation(summary = "일반 티켓 리스트 조회", description = "sort-by에 정의된 티켓 속성 기준으로 정렬된 일반 티켓 리스트를 조회합니다 " +
             "</br> sort-by를 쿼리에 포함시키지 않은 경우 (환불 요청 -> 결제 대기 -> 결제 왼료 -> 환불 완료) 순서로, 같은 결제 상태에 대해서는 최신순으로 정렬합니다")
@@ -52,6 +53,7 @@ public class AdminTicketController {
         return ApiResponse.onSuccess(ticketListResponse);
     }
 
+    @CheckUserType(userType = UserType.ADMIN)
     @GetMapping("/freshman")
     @Operation(summary = "신입생 티켓 리스트 조회", description = "sort-by에 정의된 티켓 속성 기준으로 정렬된 신입생 티켓 리스트를 조회합니다 " +
             "</br> sort-by를 쿼리에 포함시키지 않은 경우 (환불 요청 -> 결제 대기 -> 결제 왼료 -> 환불 완료) 순서로, 같은 결제 상태에 대해서는 최신순으로 정렬합니다")
@@ -61,6 +63,7 @@ public class AdminTicketController {
         return ApiResponse.onSuccess(ticketListResponse);
     }
 
+    @CheckUserType(userType = UserType.ADMIN)
     @PatchMapping("/{ticketId}/ticket-complete")
     @Operation(summary = "티켓 결제 완료", description = "티켓 결제를 완료한 뒤 어드민 페이지에서 결제 완료를 클릭하는 경우 결제 완료로 상태가 변합니다." +
             "</br> 추가적으로 티켓 구매자에게 결제 완료 확인 메일을 발송합니다.")
@@ -69,6 +72,7 @@ public class AdminTicketController {
         return ApiResponse.onSuccess(ticketUpdateResponse);
     }
 
+    @CheckUserType(userType = UserType.ADMIN)
     @PatchMapping("/{ticketId}/cancel-complete")
     @Operation(summary = "티켓 취소 완료", description = "티켓 환불을 완료한 뒤 어드민 페이지에서 취소 완료를 클릭하는 경우 취소가 완료로 상태가 변합니다.")
     public ApiResponse<TicketUpdateResponse> completeCancelForm(@PathVariable(name = "ticketId") Long ticketId, @AuthenticationPrincipal AuthDetails authDetails) {
@@ -76,6 +80,7 @@ public class AdminTicketController {
         return ApiResponse.onSuccess(ticketUpdateResponse);
     }
 
+    @CheckUserType(userType = UserType.ADMIN)
     @GetMapping("/download")
     @Operation(summary = "티켓 리스트 엑셀 변환", description = "전체 티켓 리스트를 엑셀 파일로 변환하여 다운로드합니다.")
     public ResponseEntity<InputStreamResource> applyListToExcel() throws IOException {
@@ -89,6 +94,7 @@ public class AdminTicketController {
                 .body(new InputStreamResource(in));
     }
 
+    @CheckUserType(userType = UserType.ADMIN)
     @GetMapping("/participants/download")
     @Operation(summary = "참석자 리스트 엑셀 변환", description = "전체 참석자 리스트를 엑셀 파일로 변환하여 다운로드합니다.")
     public ResponseEntity<InputStreamResource> participantsListToExcel() throws IOException {
@@ -102,6 +108,7 @@ public class AdminTicketController {
                 .body(new InputStreamResource(in));
     }
 
+    @CheckUserType(userType = UserType.ADMIN)
     @PutMapping("/{performance_id}")
     @Operation(summary = "공연 정보 수정", description = "공연 정보를 수정합니다")
     public ApiResponse<PerformanceResponse> updatePerformance(@PathVariable("performance_id") Long performanceId, @RequestBody PerformanceRequest performanceRequest, @AuthenticationPrincipal AuthDetails authDetails) {
@@ -114,6 +121,7 @@ public class AdminTicketController {
         return ApiResponse.onSuccess(ticketService.getTicketInfo(performanceId));
     }
 
+    @CheckUserType(userType = UserType.ADMIN)
     @GetMapping("/statistics")
     @Operation(summary = "티켓 통계 조회", description = "티켓 통계를 조회합니다")
     public ApiResponse<TicketStatisticsResponse> getTicketStatistics(@AuthenticationPrincipal AuthDetails authDetails) {

--- a/src/main/java/kahlua/KahluaProject/global/aop/checkAdmin/CheckUserType.java
+++ b/src/main/java/kahlua/KahluaProject/global/aop/checkAdmin/CheckUserType.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CheckUserType {
     public UserType userType();


### PR DESCRIPTION
## #️⃣연관된 이슈

> #155 

## 📝작업 내용

> 유저 타입 검증 시, adminController 맨 위에 붙이고, target에 type을 추가하면 되는 줄 알았는데, 오류가 나는 걸 확인했습니다. 따라서 각 메소드마다 붙여 해결하였습니다

### 스크린샷 (선택)
<img width="695" alt="image" src="https://github.com/user-attachments/assets/d9086aa2-1d26-407d-9f0c-cf40addfe793" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
