### PR TITLE
 Feature: user type 지정 페이지

### DIFF
--- a/src/main/java/kahlua/KahluaProject/controller/adminController/AdminApprovalController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/adminController/AdminApprovalController.java
@@ -1,7 +1,9 @@
 package kahlua.KahluaProject.controller.adminController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import kahlua.KahluaProject.domain.user.ApprovalFilter;
 import kahlua.KahluaProject.domain.user.UserType;
 import kahlua.KahluaProject.dto.user.response.UserListResponse;
 import kahlua.KahluaProject.dto.user.response.UserResponse;
@@ -22,19 +24,20 @@ public class AdminApprovalController {
 
     @GetMapping
     @CheckUserType(userType = UserType.ADMIN)
-    @Operation(summary = "깔루아 멤버리스트 API", description = """
+    @Operation(summary = "깔루아 유저리스트 API", description = """
             깔루아 멤버들의 정보를 확인할 수 있는 리스트 api입니다.
-            UserType이 ADMIN/KAHLUA일 경우 승인 상태는 APROVED,
-            PENDING일 경우에는 PENDING,
+            UserType이 ADMIN/KAHLUA일 경우 승인 상태는 APPROVED,
+            PENDING일 경우에는 승인 상태는 PENDING입니다.
             ALL을 입력할 경우 전체 멤버 명단이 조회됩니다.
             """)
+    @Parameter(name = "page", description = "페이지 번호, 0번이 1 페이지 입니다.")
     public ApiResponse<UserListResponse> getUsers(
             @AuthenticationPrincipal AuthDetails authDetails,
-            @RequestParam(defaultValue = "ALL")String approvalStatus,
+            @RequestParam ApprovalFilter approvalFilter,
             @RequestParam(defaultValue = "0")    int page,
             @RequestParam(defaultValue = "10")   int size){
 
-        UserListResponse userListResponse=userService.getUserList(approvalStatus,page,size);
+        UserListResponse userListResponse=userService.getUserList(approvalFilter,page,size);
         return ApiResponse.onSuccess(userListResponse);
     }
 

--- a/src/main/java/kahlua/KahluaProject/controller/adminController/AdminApprovalController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/adminController/AdminApprovalController.java
@@ -4,16 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kahlua.KahluaProject.domain.user.UserType;
 import kahlua.KahluaProject.dto.user.response.UserListResponse;
+import kahlua.KahluaProject.dto.user.response.UserResponse;
 import kahlua.KahluaProject.global.aop.checkAdmin.CheckUserType;
 import kahlua.KahluaProject.global.apipayload.ApiResponse;
 import kahlua.KahluaProject.global.security.AuthDetails;
 import kahlua.KahluaProject.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "관리자(멤버 관리)", description = "관리자(멤버 관리) 페이지 관련 API")
 @RestController
@@ -39,4 +37,17 @@ public class AdminApprovalController {
         UserListResponse userListResponse=userService.getUserList(approvalStatus,page,size);
         return ApiResponse.onSuccess(userListResponse);
     }
+
+    @PatchMapping("/{userId}")
+    @CheckUserType(userType = UserType.ADMIN)
+    @Operation(summary = "유저 타입 변경 API", description = "유저 타입을 변경할 수 있는 API입니다.")
+    public ApiResponse<UserResponse> changeUserType(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @PathVariable Long userId,
+            @RequestParam UserType userType){
+        UserResponse userResponse=userService.changeUserType(userId,userType);
+
+        return ApiResponse.onSuccess(userResponse);
+    }
+
 }

--- a/src/main/java/kahlua/KahluaProject/controller/adminController/AdminApprovalController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/adminController/AdminApprovalController.java
@@ -1,0 +1,42 @@
+package kahlua.KahluaProject.controller.adminController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kahlua.KahluaProject.domain.user.UserType;
+import kahlua.KahluaProject.dto.user.response.UserListResponse;
+import kahlua.KahluaProject.global.aop.checkAdmin.CheckUserType;
+import kahlua.KahluaProject.global.apipayload.ApiResponse;
+import kahlua.KahluaProject.global.security.AuthDetails;
+import kahlua.KahluaProject.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "관리자(멤버 관리)", description = "관리자(멤버 관리) 페이지 관련 API")
+@RestController
+@RequestMapping("/v1/admin/users")
+@RequiredArgsConstructor
+public class AdminApprovalController {
+    private final UserService userService;
+
+    @GetMapping
+    @CheckUserType(userType = UserType.ADMIN)
+    @Operation(summary = "깔루아 멤버리스트 API", description = """
+            깔루아 멤버들의 정보를 확인할 수 있는 리스트 api입니다.
+            UserType이 ADMIN/KAHLUA일 경우 승인 상태는 APROVED,
+            PENDING일 경우에는 PENDING,
+            ALL을 입력할 경우 전체 멤버 명단이 조회됩니다.
+            """)
+    public ApiResponse<UserListResponse> getUsers(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @RequestParam(defaultValue = "ALL")String approvalStatus,
+            @RequestParam(defaultValue = "0")    int page,
+            @RequestParam(defaultValue = "10")   int size){
+
+        UserListResponse userListResponse=userService.getUserList(approvalStatus,page,size);
+        return ApiResponse.onSuccess(userListResponse);
+    }
+}

--- a/src/main/java/kahlua/KahluaProject/domain/user/ApprovalFilter.java
+++ b/src/main/java/kahlua/KahluaProject/domain/user/ApprovalFilter.java
@@ -1,0 +1,14 @@
+package kahlua.KahluaProject.domain.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApprovalFilter {
+    PENDING("대기"), // 정보 입력O + 대기중
+    ALL("전체"),
+    APPROVED("승인");
+
+    private final String approvalStatus;
+}

--- a/src/main/java/kahlua/KahluaProject/domain/user/User.java
+++ b/src/main/java/kahlua/KahluaProject/domain/user/User.java
@@ -59,4 +59,8 @@ public class User extends BaseEntity {
         this.session = Session.valueOf(userInfoRequest.session());
         this.userType = UserType.PENDING;
     }
+
+    public void updateUserType(UserType newType) {
+        this.userType = newType;
+    }
 }

--- a/src/main/java/kahlua/KahluaProject/dto/user/response/UserListOneResponse.java
+++ b/src/main/java/kahlua/KahluaProject/dto/user/response/UserListOneResponse.java
@@ -27,7 +27,7 @@ public class UserListOneResponse {
                 .approvalStatus(
                         user.getUserType() == UserType.PENDING ? "PENDING" :
                                 (user.getUserType() == UserType.KAHLUA || user.getUserType() == UserType.ADMIN)
-                                        ? "APPROVED" : "UNACCEPTED")
+                                        ? "APROVED" : "UNACCEPTED")
                 .build();
     }
 }

--- a/src/main/java/kahlua/KahluaProject/dto/user/response/UserListOneResponse.java
+++ b/src/main/java/kahlua/KahluaProject/dto/user/response/UserListOneResponse.java
@@ -1,0 +1,33 @@
+package kahlua.KahluaProject.dto.user.response;
+
+import kahlua.KahluaProject.domain.user.LoginType;
+import kahlua.KahluaProject.domain.user.Session;
+import kahlua.KahluaProject.domain.user.User;
+import kahlua.KahluaProject.domain.user.UserType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserListOneResponse {
+    private Long term;
+    private String name;
+    private Session session;
+    private LoginType loginType;
+    private UserType userType;
+    private String approvalStatus;
+
+    public static UserListOneResponse from(User user) {
+        return UserListOneResponse.builder()
+                .term(user.getTerm())
+                .name(user.getName())
+                .session(user.getSession())
+                .loginType(user.getLoginType())
+                .userType(user.getUserType())
+                .approvalStatus(
+                        user.getUserType() == UserType.PENDING ? "PENDING" :
+                                (user.getUserType() == UserType.KAHLUA || user.getUserType() == UserType.ADMIN)
+                                        ? "APPROVED" : "UNACCEPTED")
+                .build();
+    }
+}

--- a/src/main/java/kahlua/KahluaProject/dto/user/response/UserListOneResponse.java
+++ b/src/main/java/kahlua/KahluaProject/dto/user/response/UserListOneResponse.java
@@ -1,11 +1,9 @@
 package kahlua.KahluaProject.dto.user.response;
 
-import kahlua.KahluaProject.domain.user.LoginType;
-import kahlua.KahluaProject.domain.user.Session;
-import kahlua.KahluaProject.domain.user.User;
-import kahlua.KahluaProject.domain.user.UserType;
+import kahlua.KahluaProject.domain.user.*;
 import lombok.Builder;
 import lombok.Getter;
+
 
 @Getter
 @Builder
@@ -27,7 +25,7 @@ public class UserListOneResponse {
                 .approvalStatus(
                         user.getUserType() == UserType.PENDING ? "PENDING" :
                                 (user.getUserType() == UserType.KAHLUA || user.getUserType() == UserType.ADMIN)
-                                        ? "APROVED" : "UNACCEPTED")
+                                        ? "APPROVED" : "UNAPPROVED")
                 .build();
     }
 }

--- a/src/main/java/kahlua/KahluaProject/dto/user/response/UserListResponse.java
+++ b/src/main/java/kahlua/KahluaProject/dto/user/response/UserListResponse.java
@@ -1,0 +1,43 @@
+package kahlua.KahluaProject.dto.user.response;
+
+import kahlua.KahluaProject.domain.user.User;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class UserListResponse {
+    private List<UserListOneResponse> content;
+    private long pendingCount;
+    private long approvedCount;
+    private PageInfo pageInfo;
+
+    @Getter
+    @Builder
+    public static class PageInfo {
+        private int nextPage;
+        private int lastPage;
+    }
+
+    public static UserListResponse of(Page<User> users, long pendingCount, long approvedCount) {
+
+        PageInfo pageInfo = PageInfo.builder()
+                .nextPage(users.hasNext() ? users.getNumber() + 1 : -1)
+                .lastPage(Math.max(users.getTotalPages() - 1, 0))
+                .build();
+
+        return UserListResponse.builder()
+                .content(users.getContent()
+                        .stream()
+                        .map(UserListOneResponse::from)
+                        .toList())
+                .pendingCount(pendingCount)
+                .approvedCount(approvedCount)
+                .pageInfo(pageInfo)
+                .build();
+    }
+
+}

--- a/src/main/java/kahlua/KahluaProject/dto/user/response/UserListResponse.java
+++ b/src/main/java/kahlua/KahluaProject/dto/user/response/UserListResponse.java
@@ -18,15 +18,15 @@ public class UserListResponse {
     @Getter
     @Builder
     public static class PageInfo {
-        private int nextPage;
-        private int lastPage;
+        private int totalPages; // 전체 페이지 수
+        private boolean hasNext;
     }
 
     public static UserListResponse of(Page<User> users, long pendingCount, long approvedCount) {
 
         PageInfo pageInfo = PageInfo.builder()
-                .nextPage(users.hasNext() ? users.getNumber() + 1 : -1)
-                .lastPage(Math.max(users.getTotalPages() - 1, 0))
+                .totalPages(users.getTotalPages())
+                .hasNext(users.hasNext())
                 .build();
 
         return UserListResponse.builder()

--- a/src/main/java/kahlua/KahluaProject/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/kahlua/KahluaProject/global/apipayload/code/status/ErrorStatus.java
@@ -27,7 +27,7 @@ public enum ErrorStatus implements BaseCode {
     REDIS_NOT_FOUND(HttpStatus.NOT_FOUND, "REDIS_NOT_FOUND", "Redis 설정에 오류가 발생했습니다."),
 
     //유저 에러
-    INVALID_USER_TYPE(HttpStatus.UNAUTHORIZED, "USER_NOT_ADMIN", "요구한 사용자 타입이 아닙니다."),
+    INVALID_USER_TYPE(HttpStatus.UNAUTHORIZED, "INVALID_USER_TYPE", "요구한 사용자 타입이 아닙니다."),
 
     // 세션 에러
     SESSION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "유효하지 않은 세션입니다."),

--- a/src/main/java/kahlua/KahluaProject/repository/UserRepository.java
+++ b/src/main/java/kahlua/KahluaProject/repository/UserRepository.java
@@ -1,8 +1,12 @@
 package kahlua.KahluaProject.repository;
 
 import kahlua.KahluaProject.domain.user.User;
+import kahlua.KahluaProject.domain.user.UserType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -10,4 +14,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmailAndDeletedAtIsNull(String email);
 
     Optional<User> findByIdAndDeletedAtIsNull(Long userId);
+
+    Page<User> findAllByUserTypeNot(UserType userType, Pageable pageable);
+
+    Page<User> findAllByUserType(UserType userType, Pageable pageable);
+
+    Page<User> findAllByUserTypeIn(Collection<UserType> types, Pageable pageable);
+
+    long countByUserType(UserType userType);
+    long countByUserTypeIn(Collection<UserType> userTypes);
 }

--- a/src/main/java/kahlua/KahluaProject/service/UserService.java
+++ b/src/main/java/kahlua/KahluaProject/service/UserService.java
@@ -1,5 +1,6 @@
 package kahlua.KahluaProject.service;
 
+import kahlua.KahluaProject.dto.user.response.UserListResponse;
 import kahlua.KahluaProject.global.apipayload.code.status.ErrorStatus;
 import kahlua.KahluaProject.converter.UserConverter;
 import kahlua.KahluaProject.domain.user.*;
@@ -9,8 +10,13 @@ import kahlua.KahluaProject.dto.user.response.UserResponse;
 import kahlua.KahluaProject.global.exception.GeneralException;
 import kahlua.KahluaProject.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -44,5 +50,27 @@ public class UserService {
         user.updateUserInfo(userInfoRequest);
 
         return UserConverter.toUserResDto(user);
+    }
+
+    @Transactional
+    public UserListResponse getUserList(String approvalStatus, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<User> userPage;
+
+        if (approvalStatus.equals("PENDING")) {
+            userPage= userRepository.findAllByUserType(UserType.PENDING,pageable);
+        } else if(approvalStatus.equals("APROVED")) {
+            userPage=userRepository.findAllByUserTypeIn(List.of(UserType.KAHLUA, UserType.ADMIN),pageable);
+        }else if (approvalStatus.equals("ALL")) {
+            userPage=userRepository.findAllByUserTypeNot(UserType.GENERAL, pageable);;
+        } else {
+            throw new GeneralException(ErrorStatus.INVALID_USER_TYPE);
+        }
+
+        long pendingCount  = userRepository.countByUserType(UserType.PENDING);
+        long approvedCount = userRepository.countByUserTypeIn(List.of(UserType.KAHLUA, UserType.ADMIN));
+
+        return UserListResponse.of(userPage, pendingCount, approvedCount);
+
     }
 }

--- a/src/main/java/kahlua/KahluaProject/service/UserService.java
+++ b/src/main/java/kahlua/KahluaProject/service/UserService.java
@@ -73,4 +73,15 @@ public class UserService {
         return UserListResponse.of(userPage, pendingCount, approvedCount);
 
     }
+
+    @Transactional
+    public UserResponse changeUserType(Long userId, UserType newType) {
+        User user=userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        user.updateUserType(newType);
+        userRepository.save(user);
+
+        return UserConverter.toUserResDto(user);
+    }
 }

--- a/src/main/java/kahlua/KahluaProject/service/UserService.java
+++ b/src/main/java/kahlua/KahluaProject/service/UserService.java
@@ -53,18 +53,20 @@ public class UserService {
     }
 
     @Transactional
-    public UserListResponse getUserList(String approvalStatus, int page, int size) {
+    public UserListResponse getUserList(ApprovalFilter approvalFilter, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<User> userPage;
 
-        if (approvalStatus.equals("PENDING")) {
-            userPage= userRepository.findAllByUserType(UserType.PENDING,pageable);
-        } else if(approvalStatus.equals("APROVED")) {
-            userPage=userRepository.findAllByUserTypeIn(List.of(UserType.KAHLUA, UserType.ADMIN),pageable);
-        }else if (approvalStatus.equals("ALL")) {
-            userPage=userRepository.findAllByUserTypeNot(UserType.GENERAL, pageable);;
-        } else {
-            throw new GeneralException(ErrorStatus.INVALID_USER_TYPE);
+        switch (approvalFilter) {
+            case PENDING ->
+                    userPage = userRepository.findAllByUserType(UserType.PENDING, pageable);
+            case APPROVED ->
+                    userPage = userRepository.findAllByUserTypeIn(
+                            List.of(UserType.KAHLUA, UserType.ADMIN), pageable);
+            case ALL ->
+                    userPage = userRepository.findAllByUserTypeNot(UserType.GENERAL, pageable);
+            default ->
+                    throw new GeneralException(ErrorStatus.INVALID_USER_TYPE);
         }
 
         long pendingCount  = userRepository.countByUserType(UserType.PENDING);


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #159 

## 📝작업 내용

1. Usertype를 변경하는 API 구현
<img width="726" alt="image" src="https://github.com/user-attachments/assets/c6bcd0cd-a942-4853-aa53-c1a5c55338cb" />
<img width="732" alt="image" src="https://github.com/user-attachments/assets/3ada1a5c-521a-4593-8ccf-63b7c8c83534" />

이렇게 userId랑 변경하고자하는 type 넣으면 수정되게 하였습니당

2. UserList페이지
해당 페이지가 어드민 기능이라, 오프셋 기반 페이지네이션을 사용했습니당
그리고 GENERAL타입일 때는 정보 입력을 안 한 상태라, 해당 타입 제외하고 조회되게 구현했습니다
<img width="730" alt="image" src="https://github.com/user-attachments/assets/807b200d-0143-4283-b122-30da15054d76" />
설명에 써있듯이, 승인 대기건만 보고싶다면 PENDING을, 전체 명단을 보고싶다면 ALL을 입력하시면 됩니다아
<img width="734" alt="image" src="https://github.com/user-attachments/assets/3df622ca-3ce2-4a94-8668-bb168c7e2c3b" />


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

제가 각 타입, size, page 바꿔가면서 테스트할 때 이상없긴 했습니다만,, 페이지네이션 로직에 이상한 곳 없나 확인해주세요~~~
