### PR TITLE
Fix: 멤버 리스트 응답에 userId 필드 추가 (#159)

### DIFF
--- a/src/main/java/kahlua/KahluaProject/dto/user/response/UserListOneResponse.java
+++ b/src/main/java/kahlua/KahluaProject/dto/user/response/UserListOneResponse.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class UserListOneResponse {
+    private Long id;
     private Long term;
     private String name;
     private Session session;
@@ -17,6 +18,7 @@ public class UserListOneResponse {
 
     public static UserListOneResponse from(User user) {
         return UserListOneResponse.builder()
+                .id(user.getId())
                 .term(user.getTerm())
                 .name(user.getName())
                 .session(user.getSession())


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #159

## 📝작업 내용

> userType 변경 시, userId가 필요하여 응답dto에 추가하였습니다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
<img width="931" alt="image" src="https://github.com/user-attachments/assets/a559599a-5fd9-4a6c-a837-87f1f880bb8b" />


> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

