### PR TITLE
Fix: mypage authority 추가 (#186)

### DIFF
--- a/src/main/java/kahlua/KahluaProject/global/config/SecurityConfig.java
+++ b/src/main/java/kahlua/KahluaProject/global/config/SecurityConfig.java
@@ -56,6 +56,7 @@ public class SecurityConfig {
                         .requestMatchers("/v1/auth/sign-out/**", "v1/auth/recreate/**","/v1/user/**", "/v1/admin/**").authenticated()
                         .requestMatchers("v1/reservation/**").hasAnyAuthority("KAHLUA", "ADMIN")
                         .requestMatchers("v1/comment/**").hasAnyAuthority("KAHLUA", "ADMIN")
+                        .requestMatchers("/v1/my-page/reservation").hasAnyAuthority("KAHLUA", "ADMIN")
                         .anyRequest().permitAll())
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(exceptionFilter, JwtFilter.class);


### PR DESCRIPTION
## #️⃣연관된 이슈
closed: #186 

## 📝작업 내용

기존에는 Security 설정에서 /v1/my-page/reservation API가 인증 없이 접근 가능하여 @AuthenticationPrincipal이 null로 주입되는 문제가 발생하여 authority를 추가해줬습니다.

스웨거 테스트 완료했습니다.