### PR TITLE
Feature: 공지사항&깔깔깔 검색,초성 검색 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,9 +84,10 @@ dependencies {
 	//netty
 	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.100.Final:osx-aarch_64'
 
-	//discord-logback
-	implementation 'com.github.napstr:logback-discord-appender:1.0.0'
-	implementation 'org.springframework.boot:spring-boot-starter-logging'
+	//검색기능
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'org.apache.commons:commons-lang3:3.12.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/kahlua/KahluaProject/controller/MyPageController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/MyPageController.java
@@ -6,7 +6,7 @@ import kahlua.KahluaProject.global.apipayload.ApiResponse;
 import kahlua.KahluaProject.dto.post.response.PostGetResponse;
 import kahlua.KahluaProject.dto.reservation.response.ReservationListResponse;
 import kahlua.KahluaProject.global.security.AuthDetails;
-import kahlua.KahluaProject.service.PostService;
+import kahlua.KahluaProject.service.PostSerivce.PostService;
 import kahlua.KahluaProject.service.ReservationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/src/main/java/kahlua/KahluaProject/controller/PostController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/PostController.java
@@ -2,7 +2,9 @@ package kahlua.KahluaProject.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import kahlua.KahluaProject.domain.user.UserType;
 import kahlua.KahluaProject.dto.post.response.PostListResponse;
+import kahlua.KahluaProject.global.aop.checkAdmin.CheckUserType;
 import kahlua.KahluaProject.global.apipayload.ApiResponse;
 import kahlua.KahluaProject.dto.post.request.PostCreateRequest;
 import kahlua.KahluaProject.dto.post.request.PostUpdateRequest;
@@ -79,7 +81,9 @@ public class PostController {
     }
 
     @GetMapping("/search")
+    @CheckUserType(userType = UserType.KAHLUA)
     public ResponseEntity<PostListResponse> searchPosts(
+            @AuthenticationPrincipal AuthDetails authDetails,
             @RequestParam String query,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {

--- a/src/main/java/kahlua/KahluaProject/controller/PostController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/PostController.java
@@ -2,6 +2,7 @@ package kahlua.KahluaProject.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import kahlua.KahluaProject.dto.post.response.PostListResponse;
 import kahlua.KahluaProject.global.apipayload.ApiResponse;
 import kahlua.KahluaProject.dto.post.request.PostCreateRequest;
 import kahlua.KahluaProject.dto.post.request.PostUpdateRequest;
@@ -9,13 +10,17 @@ import kahlua.KahluaProject.dto.post.response.PostCreateResponse;
 import kahlua.KahluaProject.dto.post.response.PostGetResponse;
 import kahlua.KahluaProject.dto.post.response.PostUpdateResponse;
 import kahlua.KahluaProject.global.security.AuthDetails;
-import kahlua.KahluaProject.service.PostService;
+import kahlua.KahluaProject.service.PostSerivce.PostSearchService;
+import kahlua.KahluaProject.service.PostSerivce.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 
 @Tag(name = "게시판", description = "게시판 관련 API")
@@ -25,6 +30,7 @@ import org.springframework.web.bind.annotation.*;
 public class PostController {
 
     private final PostService postService;
+    private final PostSearchService postSearchService;
 
     @PostMapping("/notice/create") 
     @Operation(summary = "공지사항 작성", description = "창립제, 악기 구비 등 깔루아 전체 공지 내용을 작성합니다.")
@@ -70,5 +76,16 @@ public class PostController {
                                                            @RequestParam(value = "search_word", required = false) String searchWord,
                                                            Pageable pageable) {
         return ApiResponse.onSuccess(postService.viewPostList(authDetails.user(), searchType, searchWord, pageable));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<PostListResponse> searchPosts(
+            @RequestParam String query,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        PostListResponse result = postSearchService.searchPosts(query, page, size);
+
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/kahlua/KahluaProject/controller/PostController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/PostController.java
@@ -2,6 +2,7 @@ package kahlua.KahluaProject.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import kahlua.KahluaProject.domain.post.PostType;
 import kahlua.KahluaProject.domain.user.UserType;
 import kahlua.KahluaProject.dto.post.response.PostListResponse;
 import kahlua.KahluaProject.global.aop.checkAdmin.CheckUserType;
@@ -34,61 +35,73 @@ public class PostController {
     private final PostService postService;
     private final PostSearchService postSearchService;
 
-    @PostMapping("/notice/create") 
-    @Operation(summary = "공지사항 작성", description = "창립제, 악기 구비 등 깔루아 전체 공지 내용을 작성합니다.")
+    @PostMapping("/create")
+    @CheckUserType(userType = UserType.KAHLUA)
+    @Operation(summary = "게시글 작성", description = """
+            공지사항/깔브리타임 게시글을 작성합니다.
+            공지사항 작성은 어드민만 가능합니다.""")
     public ApiResponse<PostCreateResponse> createPost(@RequestBody PostCreateRequest postCreateRequest, @AuthenticationPrincipal AuthDetails authDetails) {
         PostCreateResponse postCreateResponse = postService.createPost(postCreateRequest, authDetails.user());
         return ApiResponse.onSuccess(postCreateResponse);
     }
 
     @PatchMapping("/{post_id}/update")
-    @Operation(summary = "공지사항 수정", description = "공지 내용을 수정합니다. 이미지의 경우, 기존 이미지를 삭제하고 싶은 경우 빈 리스트로 전달하고 </br>" +
-            "기존 이미지를 유지하고 싶은 경우 null 값으로 데이터를 전송합니다.")
+    @CheckUserType(userType = UserType.KAHLUA)
+    @Operation(summary = "게시글 수정", description = """
+            게시글 내용을 수정합니다. 이미지의 경우, 기존 이미지를 삭제하고 싶은 경우 빈 리스트로 전달하고 
+            기존 이미지를 유지하고 싶은 경우 null 값으로 데이터를 전송합니다.
+            공지사항 수정은 어드민만 가능합니다.""")
     public ApiResponse<PostUpdateResponse> updatePost(@PathVariable("post_id") Long post_id, @RequestBody PostUpdateRequest postUpdateRequest, @AuthenticationPrincipal AuthDetails authDetails) {
         PostUpdateResponse postUpdateResponse = postService.updatePost(post_id, postUpdateRequest, authDetails.user());
         return ApiResponse.onSuccess(postUpdateResponse);
     }
 
     @PostMapping("/{post_id}/create_like")
-    @Operation(summary = "좋아요 생성/삭제", description = "게시글을 좋아요 생성/삭제를 진행합니다.")
+    @CheckUserType(userType = UserType.KAHLUA)
+    @Operation(summary = "좋아요 생성/삭제", description = "게시글의 좋아요 생성/삭제를 진행합니다.")
     public ResponseEntity<?> cratePostLike(@PathVariable("post_id") Long post_id, @AuthenticationPrincipal AuthDetails authDetails) {
         boolean result = postService.createPostLike(authDetails.user(), post_id);
         if (result == true) return ResponseEntity.ok().body(ApiResponse.onSuccess("like_create"));
         else return ResponseEntity.ok().body(ApiResponse.onSuccess("like_delete"));
     }
 
-    @GetMapping("/notice/{post_id}/detail")
-    @Operation(summary = "공지사항 내용 조회", description = "공지 내용을 조회합니다.")
+    @GetMapping("/{post_id}/detail")
+    @CheckUserType(userType = UserType.KAHLUA)
+    @Operation(summary = "게시글 내용 조회", description = "게시글 내용을 조회합니다.")
     public ApiResponse<PostGetResponse> viewPost(@PathVariable("post_id") Long post_id, @AuthenticationPrincipal AuthDetails authDetails) {
         PostGetResponse postGetResponse = postService.viewPost(post_id, authDetails.user());
         return ApiResponse.onSuccess(postGetResponse);
     }
 
-    @DeleteMapping("/notice/{post_id}/delete")
-    @Operation(summary = "공지사항 삭제", description = "선택한 공지글을 삭제합니다.")
+    @DeleteMapping("{post_id}/delete")
+    @CheckUserType(userType = UserType.KAHLUA)
+    @Operation(summary = "게시글 삭제", description = "선택한 게시글을 삭제합니다.")
     public ApiResponse<?> deletePost(@PathVariable("post_id") Long post_id, @AuthenticationPrincipal AuthDetails authDetails) {
-        postService.delete(post_id, authDetails.user());
+        postService.delete(post_id);
         return ApiResponse.onSuccess("post delete success");
     }
 
     @GetMapping("/list")
+    @CheckUserType(userType = UserType.KAHLUA)
     @Operation(summary = "게시판 목록 조회", description = "공지사항/깔브리타임 목록을 조회합니다.")
     public ApiResponse<Page<PostGetResponse>> viewPostList(@AuthenticationPrincipal AuthDetails authDetails,
                                                            @RequestParam(value = "post_type", required = false) String searchType,
                                                            @RequestParam(value = "search_word", required = false) String searchWord,
                                                            Pageable pageable) {
-        return ApiResponse.onSuccess(postService.viewPostList(authDetails.user(), searchType, searchWord, pageable));
+        return ApiResponse.onSuccess(postService.viewPostList(searchType, searchWord, pageable));
     }
 
     @GetMapping("/search")
     @CheckUserType(userType = UserType.KAHLUA)
+    @Operation(summary = "게시판 검색 결과 조회 (초성 검색 포함)", description = "공지사항/깔브리타임에서 글 제목을 검색할 경우, 그 결과를 반환합니다.")
     public ResponseEntity<PostListResponse> searchPosts(
             @AuthenticationPrincipal AuthDetails authDetails,
             @RequestParam String query,
+            @RequestParam(required = false) PostType postType,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
 
-        PostListResponse result = postSearchService.searchPosts(query, page, size);
+        PostListResponse result = postSearchService.searchPosts(query,postType, page, size);
 
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/kahlua/KahluaProject/domain/user/User.java
+++ b/src/main/java/kahlua/KahluaProject/domain/user/User.java
@@ -11,6 +11,7 @@ import org.hibernate.annotations.SQLDelete;
 @Entity
 @Getter
 @SQLDelete(sql = "UPDATE user SET deleted_at = NOW() where id = ?")
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
 
@@ -44,7 +45,7 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private LoginType loginType;
 
-    @Column(columnDefinition = "string")
+    @Column(columnDefinition = "varchar(255)")
     private String profileImageUrl;
 
     @Builder

--- a/src/main/java/kahlua/KahluaProject/dto/post/request/PostCreateRequest.java
+++ b/src/main/java/kahlua/KahluaProject/dto/post/request/PostCreateRequest.java
@@ -19,7 +19,9 @@ public class PostCreateRequest {
     @Schema(description = "게시글 내용", example = "안녕하세요 깔루아 기장입니다. 감사합니다.")
     private String content;
 
-    @Schema(description = "게시글 사진 리스트", example = "['https://bucketname.s3.region.amazonaws.com/image1.jpg']")
+    @Schema(description = "게시글 사진 리스트", example = "[\n" +
+            "    \"https://bucketname.s3.region.amazonaws.com/image1.jpg\"\n" +
+            "  ]")
     private List<PostImageCreateRequest> imageUrls;
 
     @Schema(description = "게시판 구분", example = "NOTICE")

--- a/src/main/java/kahlua/KahluaProject/dto/post/response/PostListResponse.java
+++ b/src/main/java/kahlua/KahluaProject/dto/post/response/PostListResponse.java
@@ -1,0 +1,38 @@
+package kahlua.KahluaProject.dto.post.response;
+
+import kahlua.KahluaProject.domain.post.Post;
+import kahlua.KahluaProject.dto.user.response.UserListResponse;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PostListResponse {
+    private List<PostSearchResponse> posts;
+    private PageInfo pageInfo;
+
+    @Getter
+    @Builder
+    public static class PageInfo {
+        private int totalPages;
+        private boolean hasNext;
+    }
+
+    public static PostListResponse of(Page<Post> post) {
+        PageInfo pageInfo = PageInfo.builder()
+                .totalPages(post.getTotalPages())
+                .hasNext(post.hasNext())
+                .build();
+
+        return PostListResponse.builder()
+                .posts(post.getContent()
+                        .stream()
+                        .map(PostSearchResponse::new)
+                        .toList())
+                .pageInfo(pageInfo)
+                .build();
+    }
+}

--- a/src/main/java/kahlua/KahluaProject/dto/post/response/PostSearchResponse.java
+++ b/src/main/java/kahlua/KahluaProject/dto/post/response/PostSearchResponse.java
@@ -37,7 +37,7 @@ public class PostSearchResponse {
     public PostSearchResponse(Post post) {
         this.id = post.getId();
         this.title = post.getTitle();
-        this.writer = post.getUser().getName();
+        this.writer = post.getUser().getEmail();
         this.createdAt = post.getCreatedAt();
         this.likes = post.getLikes();
         this.commentsCount = post.getComments().size();

--- a/src/main/java/kahlua/KahluaProject/dto/post/response/PostSearchResponse.java
+++ b/src/main/java/kahlua/KahluaProject/dto/post/response/PostSearchResponse.java
@@ -1,0 +1,45 @@
+package kahlua.KahluaProject.dto.post.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kahlua.KahluaProject.domain.post.Post;
+import kahlua.KahluaProject.domain.post.PostType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostSearchResponse {
+    @Schema(description = "아이디(번호)", example = "1")
+    private Long id;
+
+    @Schema(description = "게시글 제목", example = "2024년 9월 정기공연")
+    private String title;
+
+    @Schema(description = "게시글 작성자", example = "관리자")
+    private String writer;
+
+    @Schema(description = "게시글 좋아요 수", example = "13")
+    private int likes;
+
+    @Schema(description = "게시글 댓글 수", example = "5")
+    private int commentsCount;
+
+    @Schema(description = "작성한 날짜", example = "2024-08-01T00:00:00")
+    private LocalDateTime createdAt;
+
+    public PostSearchResponse(Post post) {
+        this.id = post.getId();
+        this.title = post.getTitle();
+        this.writer = post.getUser().getName();
+        this.createdAt = post.getCreatedAt();
+        this.likes = post.getLikes();
+        this.commentsCount = post.getComments().size();
+    }
+}

--- a/src/main/java/kahlua/KahluaProject/dto/post/response/PostSearchResponse.java
+++ b/src/main/java/kahlua/KahluaProject/dto/post/response/PostSearchResponse.java
@@ -37,7 +37,7 @@ public class PostSearchResponse {
     public PostSearchResponse(Post post) {
         this.id = post.getId();
         this.title = post.getTitle();
-        this.writer = post.getUser().getEmail();
+        this.writer = post.getUser() != null ? post.getUser().getName() : null;
         this.createdAt = post.getCreatedAt();
         this.likes = post.getLikes();
         this.commentsCount = post.getComments().size();

--- a/src/main/java/kahlua/KahluaProject/global/config/RedisConfig.java
+++ b/src/main/java/kahlua/KahluaProject/global/config/RedisConfig.java
@@ -1,13 +1,20 @@
 package kahlua.KahluaProject.global.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
 
 @Configuration
 @EnableRedisRepositories
@@ -29,9 +36,25 @@ public class RedisConfig {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
 
         redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setDefaultSerializer(new GenericJackson2JsonRedisSerializer());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 
         return redisTemplate;
+    }
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(30))
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer
+                        (new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer
+                        (new GenericJackson2JsonRedisSerializer()));
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(config)
+                .build();
     }
 }

--- a/src/main/java/kahlua/KahluaProject/global/utils/KoreanUtils.java
+++ b/src/main/java/kahlua/KahluaProject/global/utils/KoreanUtils.java
@@ -1,0 +1,48 @@
+package kahlua.KahluaProject.global.utils;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class KoreanUtils {
+    private static final char[] CHOSUNG ={
+            'ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ',
+            'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'
+    };
+
+    //문자열에서 초성 추출
+    public String extractInitials(String text){
+        if(text==null || text.length()==0){
+            return "";
+        }
+
+        StringBuilder chosung = new StringBuilder();
+        for (char ch : text.toCharArray()) {
+            if(isKorean(ch)){
+                int index = (ch-0xAC00) / (21 * 28);
+                if (index >=0 && index < CHOSUNG.length){
+                    chosung.append(CHOSUNG[index]);
+                }
+            } else {
+                chosung.append(ch);
+            }
+        }
+
+        return chosung.toString();
+    }
+
+    private boolean isKorean(char ch){
+        return ch>= 0xAC00 && ch <=0xD7A3;
+    }
+
+    public boolean matchesChosung(String text, String chosungQuery) {
+        String textChosung = extractInitials(text);
+        return textChosung.toLowerCase().contains(chosungQuery.toLowerCase());
+    }
+
+    public boolean isChosungQuery(String query) {
+        if (query == null || query.isEmpty()) {
+            return false;
+        }
+        return query.chars().anyMatch(ch -> ch >= 0x3131 && ch <= 0x3163);
+    }
+}

--- a/src/main/java/kahlua/KahluaProject/repository/post/PostRepository.java
+++ b/src/main/java/kahlua/KahluaProject/repository/post/PostRepository.java
@@ -1,6 +1,7 @@
 package kahlua.KahluaProject.repository.post;
 
 import kahlua.KahluaProject.domain.post.Post;
+import kahlua.KahluaProject.domain.post.PostType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,4 +19,15 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
             "LOWER(p.title) LIKE LOWER(CONCAT('%', :query, '%')) " +
             "ORDER BY p.createdAt DESC")
     Page<Post> findByTitleContainingIgnoreCase(@Param("query") String query, Pageable pageable);
+
+    @Query("SELECT p FROM Post p JOIN FETCH p.user WHERE " +
+            "LOWER(p.title) LIKE LOWER(CONCAT('%', :query, '%')) " +
+            "AND p.postType = :postType " +
+            "ORDER BY p.createdAt DESC")
+    Page<Post> findByTitleContainingIgnoreCaseAndPostType(
+            @Param("query") String query,
+            @Param("postType") PostType postType,
+            Pageable pageable);
+
+    List<Post> findByPostType(PostType postType);
 }

--- a/src/main/java/kahlua/KahluaProject/repository/post/PostRepository.java
+++ b/src/main/java/kahlua/KahluaProject/repository/post/PostRepository.java
@@ -1,11 +1,21 @@
 package kahlua.KahluaProject.repository.post;
 
 import kahlua.KahluaProject.domain.post.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 
     Optional<Post> findById(Long id);
+
+    @Query("SELECT p FROM Post p WHERE " +
+            "LOWER(p.title) LIKE LOWER(CONCAT('%', :query, '%')) " +
+            "ORDER BY p.createdAt DESC")
+    Page<Post> findByTitleContainingIgnoreCase(@Param("query") String query, Pageable pageable);
 }

--- a/src/main/java/kahlua/KahluaProject/service/PostSerivce/PostSearchService.java
+++ b/src/main/java/kahlua/KahluaProject/service/PostSerivce/PostSearchService.java
@@ -1,0 +1,55 @@
+package kahlua.KahluaProject.service.PostSerivce;
+
+import kahlua.KahluaProject.domain.post.Post;
+import kahlua.KahluaProject.dto.post.response.PostListResponse;
+import kahlua.KahluaProject.global.utils.KoreanUtils;
+import kahlua.KahluaProject.repository.post.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PostSearchService {
+
+    private final PostRepository postRepository;
+    private final AutoCompleteService autoCompleteService;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final KoreanUtils koreanUtils;
+
+    private static final String SEARCH_CACHE_KEY_PREFIX = "search:";
+
+    public PostListResponse searchPosts(String query, int page, int size) {
+        Page<Post> posts;
+        Pageable pageable = PageRequest.of(page, size);
+
+        if (koreanUtils.isChosungQuery(query)) {
+            // 초성 검색
+            List<Post> allPosts = postRepository.findAll();
+            List<Post> filteredPosts = allPosts.stream()
+                    .filter(post -> koreanUtils.matchesChosung(post.getTitle(), query))
+                    .sorted(Comparator.comparing(Post::getCreatedAt).reversed())
+                    .collect(Collectors.toList());
+
+            int start = (int) pageable.getOffset();
+            int end = Math.min(start + pageable.getPageSize(), filteredPosts.size());
+            List<Post> pagedPosts = filteredPosts.subList(start, end);
+
+            posts = new PageImpl<>(pagedPosts, pageable, filteredPosts.size());
+        } else {
+            // 일반 검색
+            posts = postRepository.findByTitleContainingIgnoreCase(query, pageable);
+        }
+
+        return PostListResponse.of(posts);
+    }
+
+}

--- a/src/main/java/kahlua/KahluaProject/service/PostSerivce/PostSearchService.java
+++ b/src/main/java/kahlua/KahluaProject/service/PostSerivce/PostSearchService.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
@@ -18,6 +19,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PostSearchService {
 
     private final PostRepository postRepository;

--- a/src/main/java/kahlua/KahluaProject/service/PostSerivce/PostService.java
+++ b/src/main/java/kahlua/KahluaProject/service/PostSerivce/PostService.java
@@ -43,14 +43,7 @@ public class PostService {
         // 공지사항인 경우 admin인지 확인
         if (postCreateRequest.getPostType() == NOTICE) {
             if (user.getUserType() != UserType.ADMIN) {
-                throw new GeneralException(ErrorStatus.UNAUTHORIZED);
-            }
-        }
-
-        // 깔깔깔인 경우 kahlua 또는 admin인지 확인
-        if (postCreateRequest.getPostType() == KAHLUA_TIME) {
-            if (user.getUserType() != UserType.KAHLUA && user.getUserType() != UserType.ADMIN) {
-                throw new GeneralException(ErrorStatus.UNAUTHORIZED);
+                throw new GeneralException(ErrorStatus.INVALID_USER_TYPE);
             }
         }
 
@@ -78,13 +71,6 @@ public class PostService {
         // 공지사항인 경우 admin인지 확인
         if (postUpdateRequest.getPostType() == NOTICE) {
             if (user.getUserType() != UserType.ADMIN) {
-                throw new GeneralException(ErrorStatus.UNAUTHORIZED);
-            }
-        }
-
-        // 깔깔깔인 경우 kahlua 또는 admin인지 확인
-        if (postUpdateRequest.getPostType() == KAHLUA_TIME) {
-            if (user.getUserType() != UserType.KAHLUA && user.getUserType() != UserType.ADMIN) {
                 throw new GeneralException(ErrorStatus.UNAUTHORIZED);
             }
         }
@@ -146,11 +132,6 @@ public class PostService {
     @Transactional
     public PostGetResponse viewPost(Long post_id, User user) {
 
-        // 공지사항 조회의 경우 kahlua 혹은 ADMIN인지 확인
-        if (user.getUserType() != UserType.KAHLUA && user.getUserType() != UserType.ADMIN) {
-            throw new GeneralException(ErrorStatus.UNAUTHORIZED);
-        }
-
         // 선택한 게시글이 존재하는 지 확인
         Post existingPost = postRepository.findById(post_id)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
@@ -161,12 +142,7 @@ public class PostService {
     }
 
     @Transactional
-    public Page<PostGetResponse> viewPostList(User user, String postType, String searchWord, Pageable pageable) {
-
-        // 공지사항 조회의 경우 kahlua 혹은 ADMIN인지 확인
-        if (user.getUserType() != UserType.KAHLUA && user.getUserType() != UserType.ADMIN) {
-            throw new GeneralException(ErrorStatus.UNAUTHORIZED);
-        }
+    public Page<PostGetResponse> viewPostList(String postType, String searchWord, Pageable pageable) {
 
         return postRepository.findPostListByPagination(postType, searchWord, pageable);
     }
@@ -179,12 +155,7 @@ public class PostService {
     }
 
     @Transactional
-    public void delete(Long post_id, User user) {
-
-        // 공지사항 삭제의 경우 kahlua 혹은 ADMIN인지 확인
-        if (user.getUserType() != UserType.KAHLUA && user.getUserType() != UserType.ADMIN) {
-            throw new GeneralException(ErrorStatus.UNAUTHORIZED);
-        }
+    public void delete(Long post_id) {
 
         Post post = postRepository.findById(post_id)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));

--- a/src/main/java/kahlua/KahluaProject/service/PostSerivce/PostService.java
+++ b/src/main/java/kahlua/KahluaProject/service/PostSerivce/PostService.java
@@ -1,4 +1,4 @@
-package kahlua.KahluaProject.service;
+package kahlua.KahluaProject.service.PostSerivce;
 
 import kahlua.KahluaProject.global.apipayload.code.status.ErrorStatus;
 import kahlua.KahluaProject.converter.PostConverter;


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #175 

## 📝작업 내용

> 깔깔깔에서 초성검색 기능을 추가하며 원래는 프론트측에서 했던 검색 기능을 백엔드로 다 옮겼습니당
(+글 타입 필터링)
추가로 이번에 post관련 service에서 아직 유저 타입 체크 로직이 남아있길래 이전에 작성했던 checkUserType 커스텀 어노테이션으로 다 바꿔뒀습니당
테슽스트 결과는 밑에 첨부해둘게요

### 스크린샷 (선택)
<img width="751" height="733" alt="스크린샷 2025-07-18 오후 5 34 17" src="https://github.com/user-attachments/assets/3cb1f604-541b-48cd-b83d-898545069b3e" />
<img width="793" height="730" alt="스크린샷 2025-07-18 오후 5 34 33" src="https://github.com/user-attachments/assets/68321720-2546-4735-a06d-8c1fcd6ae4e7" />
<img width="759" height="663" alt="스크린샷 2025-07-18 오후 5 34 43" src="https://github.com/user-attachments/assets/8e5af818-e785-44e1-943c-24226cd8b57f" />



## 💬리뷰 요구사항(선택)
