### PR TITLE
Hotfix: 메일 공연시작시각 UTC 형식 변환 (#191)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	// MySQL
+	implementation 'mysql:mysql-connector-java:8.0.33'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	// Swagger

--- a/src/main/java/kahlua/KahluaProject/controller/PostController.java
+++ b/src/main/java/kahlua/KahluaProject/controller/PostController.java
@@ -36,7 +36,7 @@ public class PostController {
     private final PostSearchService postSearchService;
 
     @PostMapping("/create")
-    @CheckUserType(userType = UserType.KAHLUA)
+    @CheckUserType(userType = {UserType.KAHLUA, UserType.ADMIN})
     @Operation(summary = "게시글 작성", description = """
             공지사항/깔브리타임 게시글을 작성합니다.
             공지사항 작성은 어드민만 가능합니다.""")
@@ -46,7 +46,7 @@ public class PostController {
     }
 
     @PatchMapping("/{post_id}/update")
-    @CheckUserType(userType = UserType.KAHLUA)
+    @CheckUserType(userType = {UserType.KAHLUA, UserType.ADMIN})
     @Operation(summary = "게시글 수정", description = """
             게시글 내용을 수정합니다. 이미지의 경우, 기존 이미지를 삭제하고 싶은 경우 빈 리스트로 전달하고 
             기존 이미지를 유지하고 싶은 경우 null 값으로 데이터를 전송합니다.
@@ -57,7 +57,7 @@ public class PostController {
     }
 
     @PostMapping("/{post_id}/create_like")
-    @CheckUserType(userType = UserType.KAHLUA)
+    @CheckUserType(userType = {UserType.KAHLUA, UserType.ADMIN})
     @Operation(summary = "좋아요 생성/삭제", description = "게시글의 좋아요 생성/삭제를 진행합니다.")
     public ResponseEntity<?> cratePostLike(@PathVariable("post_id") Long post_id, @AuthenticationPrincipal AuthDetails authDetails) {
         boolean result = postService.createPostLike(authDetails.user(), post_id);
@@ -66,7 +66,7 @@ public class PostController {
     }
 
     @GetMapping("/{post_id}/detail")
-    @CheckUserType(userType = UserType.KAHLUA)
+    @CheckUserType(userType = {UserType.KAHLUA, UserType.ADMIN})
     @Operation(summary = "게시글 내용 조회", description = "게시글 내용을 조회합니다.")
     public ApiResponse<PostGetResponse> viewPost(@PathVariable("post_id") Long post_id, @AuthenticationPrincipal AuthDetails authDetails) {
         PostGetResponse postGetResponse = postService.viewPost(post_id, authDetails.user());
@@ -74,7 +74,7 @@ public class PostController {
     }
 
     @DeleteMapping("{post_id}/delete")
-    @CheckUserType(userType = UserType.KAHLUA)
+    @CheckUserType(userType = {UserType.KAHLUA, UserType.ADMIN})
     @Operation(summary = "게시글 삭제", description = "선택한 게시글을 삭제합니다.")
     public ApiResponse<?> deletePost(@PathVariable("post_id") Long post_id, @AuthenticationPrincipal AuthDetails authDetails) {
         postService.delete(post_id);
@@ -82,7 +82,7 @@ public class PostController {
     }
 
     @GetMapping("/list")
-    @CheckUserType(userType = UserType.KAHLUA)
+    @CheckUserType(userType = {UserType.KAHLUA, UserType.ADMIN})
     @Operation(summary = "게시판 목록 조회", description = "공지사항/깔브리타임 목록을 조회합니다.")
     public ApiResponse<Page<PostGetResponse>> viewPostList(@AuthenticationPrincipal AuthDetails authDetails,
                                                            @RequestParam(value = "post_type", required = false) String searchType,
@@ -92,7 +92,7 @@ public class PostController {
     }
 
     @GetMapping("/search")
-    @CheckUserType(userType = UserType.KAHLUA)
+    @CheckUserType(userType = {UserType.KAHLUA, UserType.ADMIN})
     @Operation(summary = "게시판 검색 결과 조회 (초성 검색 포함)", description = "공지사항/깔브리타임에서 글 제목을 검색할 경우, 그 결과를 반환합니다.")
     public ResponseEntity<PostListResponse> searchPosts(
             @AuthenticationPrincipal AuthDetails authDetails,

--- a/src/main/java/kahlua/KahluaProject/global/aop/checkAdmin/CheckUserType.java
+++ b/src/main/java/kahlua/KahluaProject/global/aop/checkAdmin/CheckUserType.java
@@ -10,5 +10,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CheckUserType {
-    public UserType userType();
+    public UserType[] userType();
 }

--- a/src/main/java/kahlua/KahluaProject/global/aop/checkAdmin/UserTypeCheckAspect.java
+++ b/src/main/java/kahlua/KahluaProject/global/aop/checkAdmin/UserTypeCheckAspect.java
@@ -11,6 +11,8 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
+
 @Slf4j
 @Aspect
 @Component
@@ -18,20 +20,23 @@ public class UserTypeCheckAspect {
 
     @Before("@within(checkUserType) || @annotation(checkUserType)")
     public void checkUserType(JoinPoint joinPoint, CheckUserType checkUserType) {
-        UserType requiredUserType = checkUserType.userType();
+        UserType[] requiredUserType = checkUserType.userType();
 
         for (Object arg : joinPoint.getArgs()) {
 
             if (arg instanceof AuthDetails authDetails) {
                 UserType actualType = authDetails.user().getUserType();
-                if (actualType != requiredUserType) {
+                boolean match = Arrays.asList(requiredUserType).contains(actualType);
+                if (!match) {
                     throw new GeneralException(ErrorStatus.INVALID_USER_TYPE);
                 }
                 return;
             }
 
             if (arg instanceof User user) {
-                if (user.getUserType() != requiredUserType) {
+                UserType actualType = user.getUserType();
+                boolean match = Arrays.asList(requiredUserType).contains(actualType); // ← 핵심 수정
+                if (!match) {
                     throw new GeneralException(ErrorStatus.INVALID_USER_TYPE);
                 }
                 return;

--- a/src/main/java/kahlua/KahluaProject/global/utils/TimeFormatUtils.java
+++ b/src/main/java/kahlua/KahluaProject/global/utils/TimeFormatUtils.java
@@ -1,0 +1,34 @@
+package kahlua.KahluaProject.global.utils;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.ZoneId;
+import java.util.Locale;
+
+public class TimeFormatUtils {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private static final DateTimeFormatter MONTH_FORMATTER = DateTimeFormatter.ofPattern("M월", Locale.KOREAN);
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("M월 d일 (E)", Locale.KOREAN);
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm", Locale.KOREAN);
+
+    public static String toMonthKST(LocalDateTime time) {
+        return toKST(time).format(MONTH_FORMATTER);
+    }
+
+    public static String toDateKST(LocalDateTime time) {
+        return toKST(time).format(DATE_FORMATTER);
+    }
+
+    public static String toTimeKST(LocalDateTime time) {
+        return toKST(time).format(TIME_FORMATTER);
+    }
+
+    private static ZonedDateTime toKST(LocalDateTime utcTime) {
+        // LocalDateTime을 UTC 기준으로 간주하여 ZonedDateTime으로 변환 후 KST로 변환
+        return utcTime.atZone(ZoneOffset.UTC).withZoneSameInstant(KST);
+    }
+}

--- a/src/main/java/kahlua/KahluaProject/repository/ApplyInfoRepository.java
+++ b/src/main/java/kahlua/KahluaProject/repository/ApplyInfoRepository.java
@@ -1,7 +1,11 @@
 package kahlua.KahluaProject.repository;
 
 import kahlua.KahluaProject.domain.applyInfo.ApplyInfo;
+import kahlua.KahluaProject.domain.kahluaInfo.LeaderInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ApplyInfoRepository extends JpaRepository<ApplyInfo, Long> {
+        Optional<ApplyInfo> findTopByOrderByIdDesc();
 }

--- a/src/main/java/kahlua/KahluaProject/repository/performance/PerformanceRepository.java
+++ b/src/main/java/kahlua/KahluaProject/repository/performance/PerformanceRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 @Repository
 public interface PerformanceRepository extends JpaRepository<Performance, Long>, PerformanceCustomRepository {
     Optional<Performance> findTopByOrderByCreatedAtDesc();
+    Optional<Performance> findTopByOrderByIdDesc();
 }

--- a/src/main/java/kahlua/KahluaProject/service/MailCacheService.java
+++ b/src/main/java/kahlua/KahluaProject/service/MailCacheService.java
@@ -1,46 +1,47 @@
 package kahlua.KahluaProject.service;
 
+import jakarta.annotation.PostConstruct;
 import kahlua.KahluaProject.domain.applyInfo.ApplyInfo;
 import kahlua.KahluaProject.domain.kahluaInfo.LeaderInfo;
 import kahlua.KahluaProject.domain.performance.Performance;
+import kahlua.KahluaProject.repository.ApplyInfoRepository;
+import kahlua.KahluaProject.repository.kahluaInfo.LeaderInfoRepository;
+import kahlua.KahluaProject.repository.performance.PerformanceRepository;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.CachePut;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class MailCacheService {
+    private final LeaderInfoRepository leaderInfoRepository;
+    private final ApplyInfoRepository applyInfoRepository;
+    private final PerformanceRepository performanceRepository;
+
+    // getter
+    @Getter
     private LeaderInfo leaderInfo;
+    @Getter
     private ApplyInfo applyInfo;
+    @Getter
     private Performance performance;
 
-    @Cacheable(value = "leaderInfo")
-    public LeaderInfo getLeaderInfo() {
-        return this.leaderInfo;
+    @PostConstruct
+    public void init() {
+        this.leaderInfo = leaderInfoRepository.findTopByOrderByIdDesc().orElse(null);
+        this.applyInfo = applyInfoRepository.findTopByOrderByIdDesc().orElse(null);
+        this.performance = performanceRepository.findTopByOrderByIdDesc().orElse(null);
     }
 
-    @CachePut(value = "leaderInfo")
+    // setter
     public void updateLeaderInfo(LeaderInfo leaderInfo) {
         this.leaderInfo = leaderInfo;
     }
 
-    @Cacheable(value = "applyInfo")
-    public ApplyInfo getApplyInfo() {
-        return this.applyInfo;
-    }
-
-    @CachePut(value = "applyInfo")
     public void updateApplyInfo(ApplyInfo applyInfo) {
         this.applyInfo = applyInfo;
     }
 
-    @Cacheable(value = "performance")
-    public Performance getPerformance() {
-        return this.performance;
-    }
-
-    @CachePut(value = "performance")
     public void updatePerformance(Performance performance) {
         this.performance = performance;
     }

--- a/src/main/java/kahlua/KahluaProject/service/MailService.java
+++ b/src/main/java/kahlua/KahluaProject/service/MailService.java
@@ -8,6 +8,8 @@ import kahlua.KahluaProject.domain.kahluaInfo.LeaderInfo;
 import kahlua.KahluaProject.domain.performance.Performance;
 import kahlua.KahluaProject.domain.ticket.Ticket;
 import kahlua.KahluaProject.domain.ticket.Type;
+import kahlua.KahluaProject.global.utils.TimeFormatUtils;
+import kahlua.KahluaProject.vo.PerformanceData;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -19,6 +21,8 @@ import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 @Service
 @RequiredArgsConstructor
@@ -103,13 +107,16 @@ public class MailService {
         context.setVariable("reservationId", ticket.getReservationId());
         context.setVariable("leaderName", leaderInfo.getLeaderName());
         context.setVariable("leaderPhoneNum", leaderInfo.getLeaderPhoneNum());
-        context.setVariable("performanceMonth", performance.getPerformanceData().performanceStartTime().format(DateTimeFormatter.ofPattern("M")));
-        context.setVariable("performanceStartDate", performance.getPerformanceData().performanceStartTime().format(DateTimeFormatter.ofPattern("M월 d일")));
-        context.setVariable("performanceStartTime", performance.getPerformanceData().performanceStartTime().format(DateTimeFormatter.ofPattern("HH시 mm분")));
-        context.setVariable("performanceEndTime", performance.getPerformanceData().performanceEndTime().format(DateTimeFormatter.ofPattern("HH시 mm분")));
-        context.setVariable("entranceTime", performance.getPerformanceData().entranceTime().format(DateTimeFormatter.ofPattern("HH시 mm분")));
-        context.setVariable("venue", performance.getPerformanceData().venue());
-        context.setVariable("address", performance.getPerformanceData().address());
+
+        PerformanceData data = performance.getPerformanceData();
+
+        context.setVariable("performanceMonth", TimeFormatUtils.toMonthKST(data.performanceStartTime()));
+        context.setVariable("performanceStartDate", TimeFormatUtils.toDateKST(data.performanceStartTime()));
+        context.setVariable("performanceStartTime", TimeFormatUtils.toTimeKST(data.performanceStartTime()));
+        context.setVariable("performanceEndTime", TimeFormatUtils.toTimeKST(data.performanceEndTime()));
+        context.setVariable("entranceTime", TimeFormatUtils.toTimeKST(data.entranceTime()));
+        context.setVariable("venue", data.venue());
+        context.setVariable("address", data.address());
 
         if (ticket.getType() == Type.GENERAL) {
             context.setVariable("count", participantsService.getTotalGeneralTicket(ticket.getId()));

--- a/src/main/java/kahlua/KahluaProject/service/TicketService.java
+++ b/src/main/java/kahlua/KahluaProject/service/TicketService.java
@@ -72,7 +72,7 @@ public class TicketService {
 
     //티켓 결제 완료한 경우
     @Transactional
-    @CheckUserType(userType = UserType.ADMIN)
+    //@CheckUserType(userType = UserType.ADMIN)
     public TicketUpdateResponse completePayment(Long ticketId) {
 
         Ticket existingTicket = ticketRepository.findById(ticketId)

--- a/src/main/resources/templates/ticketFreshman.html
+++ b/src/main/resources/templates/ticketFreshman.html
@@ -5,7 +5,7 @@
     <title>홍익대학교 깔루아 공연 예매 확인</title>
 </head>
 <body style="line-height: 160%">
-<h3>깔루아 [[${performanceMonth}]]월 공연 신입생 예매 확인</h3>
+<h3>깔루아 [[${performanceMonth}]] 공연 신입생 예매 확인</h3>
 <hr color="#5770F4" size="3" />
 <p>
     안녕하세요! 홍익대 깔루아 학회장 [[${leaderName}]]입니다! 우선 저희 깔루아 공연에 참석해주셔서 감사합니다.<br />
@@ -27,8 +27,8 @@
     <hr color="#CBCDD7" size="2" />
     <p style="padding-left: 8px">
         날짜 : [[${performanceStartDate}]] 월요일<br />
-        공연시간 : 오후 [[${performanceStartTime}]] ~ [[${performanceEndTime}]]<br />
-        입장시간 : 오후 [[${entranceTime}]] ~ (중도입장 가능)<br />
+        공연시간 : [[${performanceStartTime}]] ~ [[${performanceEndTime}]]<br />
+        입장시간 : [[${entranceTime}]] ~ (중도입장 가능)<br />
         장소 : [[${venue}]] ([[${address}]])<br />
     </p>
 </div>

--- a/src/main/resources/templates/ticketGeneral.html
+++ b/src/main/resources/templates/ticketGeneral.html
@@ -26,8 +26,8 @@
     <hr color="#CBCDD7" size="2" />
     <p style="padding-left: 8px">
         날짜 : [[${performanceStartDate}]] 월요일<br />
-        공연시간 : 오후 [[${performanceStartTime}]] ~ 오후 [[${performanceEndTime}]]<br />
-        입장시간 : 오후 [[${entranceTime}]] ~ (중도입장 가능)<br />
+        공연시간 : [[${performanceStartTime}]] ~ [[${performanceEndTime}]]<br />
+        입장시간 : [[${entranceTime}]] ~ (중도입장 가능)<br />
         장소 : [[${venue}]] ([[${address}]])<br />
     </p>
 </div>


### PR DESCRIPTION
## #️⃣연관된 이슈
close: #191 

## 📝작업 내용
1. 공연 시작/종료/입장 시간 포맷 이슈 해결 - TimeFormatUtils 유틸 클래스 추가
- ZonedDateTime을 사용하여 포맷하던 코드 제거
- performanceStartTime, performanceEndTime, entranceTime 모두 UTC 입력값을 KST로 포맷해 출력
```java
context.setVariable("performanceStartTime", TimeFormatUtils.toTimeKST(data.performanceStartTime()));
```
2. MailCacheService 내 캐싱 null 문제 해결
- 캐시된 LeaderInfo, Performance, ApplyInfo 중 하나라도 null일 경우 발생하던 NPE로 인한 500 에러 발생
- 해당 부분에서 Optional 또는 null 체크 및 **캐시 초기화 코드 추가**

## 📸스크린샷
<img width="942" height="258" alt="image" src="https://github.com/user-attachments/assets/a0b89cb5-bec2-4cb5-9522-498bcf6cdaa1" />
